### PR TITLE
#16 text fields improvements

### DIFF
--- a/TextFieldsCatalog/Library/BaseClasses/InnerTextField.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerTextField.swift
@@ -9,33 +9,33 @@
 import UIKit
 
 /// Class for UITextField with some extra features, it uses inside custom textFields in the project
-final class InnerTextField: UITextField {
+public final class InnerTextField: UITextField {
 
     // MARK: - Properties
 
-    var pasteActionEnabled: Bool = true
-    var textPadding: UIEdgeInsets = UIEdgeInsets.zero
-    var placeholderPadding: UIEdgeInsets = UIEdgeInsets.zero
+    public var pasteActionEnabled: Bool = true
+    public var textPadding: UIEdgeInsets = UIEdgeInsets.zero
+    public var placeholderPadding: UIEdgeInsets = UIEdgeInsets.zero
 
     // MARK: - UIView
 
-    override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         removeRightView()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 
-    override func awakeFromNib() {
+    override public func awakeFromNib() {
         super.awakeFromNib()
         removeRightView()
     }
 
     // MARK: - UITextField
 
-    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+    override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if !pasteActionEnabled, action == #selector(UIResponderStandardEditActions.paste(_:)) {
             return false
         }
@@ -54,7 +54,7 @@ final class InnerTextField: UITextField {
         return bounds.inset(by: placeholderPadding)
     }
 
-    override var isSecureTextEntry: Bool {
+    override public var isSecureTextEntry: Bool {
         didSet {
             if isFirstResponder {
                 _ = becomeFirstResponder()
@@ -62,7 +62,7 @@ final class InnerTextField: UITextField {
         }
     }
 
-    override func becomeFirstResponder() -> Bool {
+    override public func becomeFirstResponder() -> Bool {
         let success = super.becomeFirstResponder()
         if isSecureTextEntry, let text = self.text {
             self.text?.removeAll()
@@ -73,7 +73,7 @@ final class InnerTextField: UITextField {
 
     // MARK: - Internal Methods
 
-    func fixCursorPosition() {
+    public func fixCursorPosition() {
         let beginning = beginningOfDocument
         selectedTextRange = textRange(from: beginning, to: beginning)
         let end = endOfDocument

--- a/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
+++ b/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
@@ -235,6 +235,8 @@ open class BorderedTextField: InnerDesignableView, ResetableField {
         state = .disabled
         textField.isEnabled = false
         updateUI()
+        /// fix for bug, when text field not changing his textColor on iphone 6+
+        textField.text = currentText()
     }
 
     /// Enable text field
@@ -242,6 +244,8 @@ open class BorderedTextField: InnerDesignableView, ResetableField {
         state = .normal
         textField.isEnabled = true
         updateUI()
+        /// fix for bug, when text field not changing his textColor on iphone 6+
+        textField.text = currentText()
     }
 
     /// Return true if current state allows you to interact with this field

--- a/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
+++ b/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
@@ -148,6 +148,11 @@ open class BorderedTextField: InnerDesignableView, ResetableField {
         }
     }
 
+    /// Allows you to set autocapitalization type for textField
+    public func configure(autocapitalizationType: UITextAutocapitalizationType) {
+        textField.autocapitalizationType = autocapitalizationType
+    }
+
     /// Allows you to change current mode
     public func setTextFieldMode(_ mode: BorderedTextFieldMode) {
         self.mode = mode

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -151,6 +151,11 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField {
         }
     }
 
+    /// Allows you to set autocapitalization type for textField
+    public func configure(autocapitalizationType: UITextAutocapitalizationType) {
+        textField.autocapitalizationType = autocapitalizationType
+    }
+
     /// Allows you to set textContent type for textField
     public func configureContentType(_ contentType: UITextContentType) {
         textField.textContentType = contentType

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -253,6 +253,8 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField {
         state = .disabled
         textField.isEnabled = false
         updateUI()
+        /// fix for bug, when text field not changing his textColor on iphone 6+
+        textField.text = currentText()
     }
 
     /// Enable text field
@@ -260,6 +262,8 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField {
         state = .normal
         textField.isEnabled = true
         updateUI()
+        /// fix for bug, when text field not changing his textColor on iphone 6+
+        textField.text = currentText()
     }
 
     /// Return true if current state allows you to interact with this field


### PR DESCRIPTION
Решает сразу два issues:
https://github.com/chausovSurfStudio/TextFieldsCatalog/issues/15
https://github.com/chausovSurfStudio/TextFieldsCatalog/issues/16

По поводу первого:
на девайсах семейства + (6+, 7+) прямо таки стабильно воспроизводился баг, что при вызове disable/enableTextField поле реально дизейблилось/становилось активным, но цвет текста не менялся. Нагуглил, что достаточно переустановить текст (textField.text = textField.text), вроде помогло

По поводу второго:
сделал отдельный метод для конфигурации autocapitalizationType, и сделал класс InnerTextField с его свойствами и методами публичным - оказался полезен сам по себе.