### PR TITLE
added accessibility identifiers to the internal elements of text field

### DIFF
--- a/TextFieldsCatalog.xcodeproj/project.pbxproj
+++ b/TextFieldsCatalog.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		90A32B8C228991900036C634 /* leftArrow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 90A32B86228991900036C634 /* leftArrow@2x.png */; };
 		90A32B8D228991900036C634 /* rightArrow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 90A32B87228991900036C634 /* rightArrow@2x.png */; };
 		90A32B8E228991900036C634 /* rightArrow.png in Resources */ = {isa = PBXBuildFile; fileRef = 90A32B88228991900036C634 /* rightArrow.png */; };
+		90A5D38D228E9AEF000322A2 /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A5D38C228E9AEF000322A2 /* AccessibilityIdentifiers.swift */; };
 		90AE5490220582C50054E875 /* HeightLayoutPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AE548F220582C50054E875 /* HeightLayoutPolicy.swift */; };
 		90BB47272200651800F6DB39 /* AssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BB47262200651800F6DB39 /* AssetManager.swift */; };
 		90BB472F220065F000F6DB39 /* eyeOff@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 90BB4729220065F000F6DB39 /* eyeOff@2x.png */; };
@@ -113,6 +114,7 @@
 		90A32B86228991900036C634 /* leftArrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "leftArrow@2x.png"; sourceTree = "<group>"; };
 		90A32B87228991900036C634 /* rightArrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "rightArrow@2x.png"; sourceTree = "<group>"; };
 		90A32B88228991900036C634 /* rightArrow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = rightArrow.png; sourceTree = "<group>"; };
+		90A5D38C228E9AEF000322A2 /* AccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifiers.swift; sourceTree = "<group>"; };
 		90AE548F220582C50054E875 /* HeightLayoutPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightLayoutPolicy.swift; sourceTree = "<group>"; };
 		90BB47262200651800F6DB39 /* AssetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetManager.swift; sourceTree = "<group>"; };
 		90BB4729220065F000F6DB39 /* eyeOff@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "eyeOff@2x.png"; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 			children = (
 				902CE2EE21FF702F00AC21D4 /* SharedRegex.swift */,
 				90AE548F220582C50054E875 /* HeightLayoutPolicy.swift */,
+				90A5D38C228E9AEF000322A2 /* AccessibilityIdentifiers.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -701,6 +704,7 @@
 				902CE2F821FF70E500AC21D4 /* ConfigurationParameters.swift in Sources */,
 				902CE2ED21FF6D9C00AC21D4 /* Strings.swift in Sources */,
 				909DB887220355F000F0C5B7 /* String.swift in Sources */,
+				90A5D38D228E9AEF000322A2 /* AccessibilityIdentifiers.swift in Sources */,
 				902CE2F121FF707E00AC21D4 /* FormatterMasks.swift in Sources */,
 				9038640A21FF59D300BAA761 /* Foundation.swift in Sources */,
 			);

--- a/TextFieldsCatalog/Resources/Constants/AccessibilityIdentifiers.swift
+++ b/TextFieldsCatalog/Resources/Constants/AccessibilityIdentifiers.swift
@@ -1,0 +1,16 @@
+//
+//  AccessibilityIdentifiers.swift
+//  TextFieldsCatalog
+//
+//  Created by Александр Чаусов on 17/05/2019.
+//  Copyright © 2019 Александр Чаусов. All rights reserved.
+//
+
+import Foundation
+
+/// Reusable constants that are added to the user-specified identifier when setting the identifier for the internal field elements
+enum AccessibilityIdentifiers {
+    static let field = "_input"
+    static let button = "_button"
+    static let hint = "_hint"
+}

--- a/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
+++ b/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
@@ -202,6 +202,19 @@ open class BorderedTextField: InnerDesignableView, ResetableField {
         return textField.text
     }
 
+    /// This method hide keyboard, when textField will be activated (e.g., for textField with date, which connectes with DatePicker)
+    public func hideKeyboard() {
+        textField.inputView = UIView()
+    }
+
+    /// Allows to set accessibilityIdentifier for textField and its internal elements
+    public func setTextFieldIdentifier(_ identifier: String) {
+        view.accessibilityIdentifier = identifier
+        textField.accessibilityIdentifier = identifier + AccessibilityIdentifiers.field
+        actionButton.accessibilityIdentifier = identifier + AccessibilityIdentifiers.button
+        hintLabel.accessibilityIdentifier = identifier + AccessibilityIdentifiers.hint
+    }
+
     /// Allows to set view in 'error' state, optionally allows you to set the error message. If errorMessage is nil - label keeps the previous hint message
     public func setError(with errorMessage: String?) {
         error = true

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -215,9 +215,12 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField {
         textField.inputView = UIView()
     }
 
-    /// Allows to set accessibilityIdentifier for textField
+    /// Allows to set accessibilityIdentifier for textField and its internal elements
     public func setTextFieldIdentifier(_ identifier: String) {
-        textField.accessibilityIdentifier = identifier
+        view.accessibilityIdentifier = identifier
+        textField.accessibilityIdentifier = identifier + AccessibilityIdentifiers.field
+        actionButton.accessibilityIdentifier = identifier + AccessibilityIdentifiers.button
+        hintLabel.accessibilityIdentifier = identifier + AccessibilityIdentifiers.hint
     }
 
     /// Allows to set view in 'error' state, optionally allows you to set the error message. If errorMessage is nil - label keeps the previous info message


### PR DESCRIPTION
Добавил возможность ставить accessibility identifier, необходимый для автотестов, не только на поле ввода (UITextField), но и на сам контейнер с полем ввода, а также на кнопку и лейбл с подсказкой