### PR TITLE
Dev/documentation fixes

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -453,4 +453,4 @@ final class TextFormatter {
 
 ## Кастомизация
 
-В следующем [документе](./Configuration.md) вы можете найти подробную инструкцию о возможностях кастомизации полей ввода.
+В следующем [документе](https://github.com/chausovSurfStudio/TextFieldsCatalog/blob/master/Docs/Configuration.md) вы можете найти подробную инструкцию о возможностях кастомизации полей ввода.

--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -30,14 +30,14 @@
 
 ### BorderedTextField
 <p align="center">
-	<img src="./Images/BorderedTextField.png" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/BorderedTextField.png" />
 </p>
  
 Отличительная особенность поля - оно имеет статичный плейсхолдер, а UITextField имеет границу.
 
 ### UnderlinedTextField
 <p align="center">
-	<img src="./Images/UnderlinedTextField.png" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/UnderlinedTextField.png" />
 </p>
 
 Отличительными особенностями данного поля являются:
@@ -47,7 +47,7 @@
 
 ### UnderlinedTextView
 <p align="center">
-	<img src="./Images/UnderlinedTextView.png" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/UnderlinedTextView.png" />
 </p>
 
 Данное поле - обертка над UITextView, а не над UITextField, как предыдущие. Область применения - поля ввода, где ожидается наличие большого количества текста, который пользователь должен видеть полностью, потому поле при увеличении количества текста растягивается в высоту.
@@ -205,7 +205,7 @@ func setReturnKeyType(_ type: UIReturnKeyType)
 ### DatePickerView
 
 <p align="center">
-	<img src="./Images/DatePickerView.png" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/DatePickerView.png" />
 </p>
 
 Клавиатура представляет собой обертку над обычным UIDatePicker. В самом простом случае - вам будет достаточно выполнить следующие шаги:
@@ -278,13 +278,13 @@ field.inputView = DatePickerView.default(for: field)
 В результате, DatePickerView может выглядеть следующим образом:
 
 <p align="center">
-	<img src="./Images/DatePickerViewCustomized.png" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/DatePickerViewCustomized.png" />
 </p>
 
 ### PlainPickerView
 
 <p align="center">
-	<img src="./Images/PlainPickerView.png" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/PlainPickerView.png" />
 </p>
 
 Представляет собой обертку над самым обычным UIPickerView. Принцип работы и кастомизации аналогичен DatePickerView, потому в данной секции будут описаны только особенности PlainPickerView:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Данный репозиторий содержит коллекцию различных полей ввода, предоставляющих богатые возможности по проверке введенных значений и форматированию текста при вводе. К тому же, они просто симпатичные и хорошо кастомизируются :)
 
 <p align="center">
-	<img src="./Docs/Images/TextFieldsCatalog_video.gif" />
+	<img src="https://raw.githubusercontent.com/chausovSurfStudio/TextFieldsCatalog/master/Docs/Images/TextFieldsCatalog_video.gif" />
 </p>
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ textField.configure(autocapitalizationType: .words)
 textField.validator = TextFieldValidator(minLength: 5, maxLength: 25, regex: nil)
 ````
 
-Этих действий вполне достаточно для базовой конфигурации поля ввода. Для получения более подробной информации - рекомендуется посмотреть Example проект и прочитать [документацию](/Docs/Usage.md).
+Этих действий вполне достаточно для базовой конфигурации поля ввода. Для получения более подробной информации - рекомендуется посмотреть Example проект и прочитать [документацию][usage].
 
 ## Строение репозитория
 
@@ -49,12 +49,21 @@ textField.validator = TextFieldValidator(minLength: 5, maxLength: 25, regex: nil
 
 ## Документация
 
-[Документация по тестовому проекту](/Docs/ExampleProject.md)
+[Документация по тестовому проекту][exampleProject]
 
-[Документ по проекту с каталогом полей ввода](/Docs/PodProject.md)
+[Документ по проекту с каталогом полей ввода][podProject]
 
-[Документация по возможностям полей ввода](/Docs/Usage.md)
+[Документация по возможностям полей ввода][usage]
 
 ## Лицензия
 
-TextFieldsCatalog распространяется под MIT [лицензией](./LICENSE.md)
+TextFieldsCatalog распространяется под MIT [лицензией][license]
+
+
+
+
+[configuration]:	https://github.com/chausovSurfStudio/TextFieldsCatalog/blob/master/Docs/Configuration.md
+[exampleProject]:	https://github.com/chausovSurfStudio/TextFieldsCatalog/blob/master/Docs/ExampleProject.md
+[podProject]:		https://github.com/chausovSurfStudio/TextFieldsCatalog/blob/master/Docs/PodProject.md
+[usage]:			https://github.com/chausovSurfStudio/TextFieldsCatalog/blob/master/Docs/Usage.md
+[license]:			https://github.com/chausovSurfStudio/TextFieldsCatalog/blob/master/LICENSE


### PR DESCRIPTION
Поправил относительные перекрестные ссылки в документации, теперь они абсолютные (надеюсь, с сайта CocoaPods теперь будет открываться), а также задал норм ссылки на картинки (чтобы с того же сайта CocoaPods все прогружалось и отображалось)