### PR TITLE
define zero hint height for empty hint message

### DIFF
--- a/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
+++ b/TextFieldsCatalog/TextFields/BorderedTextField/BorderedTextField.swift
@@ -624,7 +624,7 @@ private extension BorderedTextField {
 
     func hintLabelHeight() -> CGFloat {
         let hintIsVisible = shouldShowHint()
-        if let hint = hintLabel.text, hintIsVisible {
+        if let hint = hintLabel.text, !hint.isEmpty, hintIsVisible {
             return hint.height(forWidth: hintLabel.bounds.size.width, font: configuration.hint.font, lineHeight: configuration.hint.lineHeight)
         }
         return 0

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -700,7 +700,7 @@ private extension UnderlinedTextField {
 
     func hintLabelHeight() -> CGFloat {
         let hintIsVisible = shouldShowHint()
-        if let hint = hintLabel.text, hintIsVisible {
+        if let hint = hintLabel.text, !hint.isEmpty, hintIsVisible {
             return hint.height(forWidth: hintLabel.bounds.size.width, font: configuration.hint.font, lineHeight: configuration.hint.lineHeight)
         }
         return 0

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -517,7 +517,7 @@ private extension UnderlinedTextView {
 
     func hintLabelHeight() -> CGFloat {
         let hintIsVisible = shouldShowHint()
-        if let hint = hintLabel.text, hintIsVisible {
+        if let hint = hintLabel.text, !hint.isEmpty, hintIsVisible {
             return hint.height(forWidth: hintLabel.bounds.size.width, font: configuration.hint.font, lineHeight: configuration.hint.lineHeight)
         }
         return 0


### PR DESCRIPTION
Ну здесь все просто: по старой логике - если хинт равнялся пустой строке, то место под него отводилось и поле могло увеличиваться в размерах (хотя это могло быть и не к месту). Так что добавил лишнюю проверочку, теперь если хинт пустой - то и высота под него высчитываться не будет.