### PR TITLE
added ability to ingore mask formatter on setup text action

### DIFF
--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -240,9 +240,16 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     }
 
     /// Allows you to set optional string as text.
-    /// Also you can disable automatic validation on this action.
-    public func setup(text: String?, validateText: Bool = true) {
-        if let formatter = maskFormatter {
+    /// - Parameters:
+    ///     - text: text for setup
+    ///     - ignoreFormatter: allows you apply format from `maskFormatter` or ignore it,
+    ///     false by default
+    ///     - validateText: allows you disable automatic text validation on this action,
+    ///     true by default
+    public func setup(text: String?,
+                      ignoreFormatter: Bool = false,
+                      validateText: Bool = true) {
+        if let formatter = maskFormatter, !ignoreFormatter {
             formatter.format(string: text, field: textField)
         } else {
             textField.text = text


### PR DESCRIPTION
Простенький метод, возникла на реальном кейсе его необходимость:

* поле ввода номера телефона, присутствует maskFormatter
* тапаем на поле
* появляется текст "+7 (", фокус после последнего символа
* снимаем фокус
* по ТЗ - предзаполненный текст должен уйти

На деле же - без костылей этого сделать было нельзя, так как маска не позволяла: при установке textField.text = "" или при ручном вызове метода для установки текста - юзался форматтер и поле снова предзаполнялась вышесказанным текстом.

Так что добавил возможность для обхода данной маски, сохранив обратную совместимость с прошлыми версиями.