### PR TITLE
Spm support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Test
       run: |
         make test
+    - name: Package build
+      run: |
+        swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios12.1-simulator" -Xswiftc "-lswiftUIKit"
     - name: documentation
       if: github.ref == 'refs/heads/master'
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ DerivedData
 *dSYM
 *dSYM.zip
 *.mobileprovision
+.build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install:
 script:
   - set -o pipefail
   - xcodebuild clean build -sdk iphonesimulator -workspace TextFieldsCatalog.xcworkspace -scheme TextFieldsCatalog CODE_SIGNING_REQUIRED=NO | xcpretty -c
+  - swift build -v -Xswiftc "-sdk" -Xswiftc "xcrun --sdk iphonesimulator --show-sdk-path" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios13.0-simulator"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   - set -o pipefail
   - xcodebuild clean build -sdk iphonesimulator -workspace TextFieldsCatalog.xcworkspace -scheme TextFieldsCatalog CODE_SIGNING_REQUIRED=NO | xcpretty -c
-  - swift build -v -Xswiftc "-sdk" -Xswiftc "xcrun --sdk iphonesimulator --show-sdk-path" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios13.0-simulator"
+  - swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios12.1-simulator" -Xswiftc "-lswiftUIKit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: Swift
-osx_image: xcode11.2
+osx_image: xcode12.1
 xcode_project: TextFieldsCatalog.xcodeproj
 xcode_scheme: TextFieldsCatalog
 before_install:

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,8 +3,8 @@ platform :ios, '10.0'
 inhibit_all_warnings!
 
 def utils
-    pod 'SwiftGen', '5.2.1'
-    pod 'SwiftLint', '0.29.4'
+    pod 'SwiftGen', '6.4.0'
+    pod 'SwiftLint', '0.41.0'
 end
 
 def common_pods

--- a/Example/TextFieldsCatalogExample/Resources/Colors/Color.swift
+++ b/Example/TextFieldsCatalogExample/Resources/Colors/Color.swift
@@ -12,16 +12,16 @@ import UIKit
 enum Color {
     /// Main color with its names from Figma
     private enum Figma {
-        static let bold = Asset.Colors.background.color
-        static let regular = Asset.Colors.regular.color
-        static let active = Asset.Colors.active.color
-        static let activePress = Asset.Colors.activePress.color
-        static let text = Asset.Colors.text.color
-        static let highlighted = Asset.Colors.highlighted.color
-        static let error = Asset.Colors.error.color
-        static let placeholderGray = Asset.Colors.placeholderGray.color
-        static let fieldNormal = Asset.Colors.fieldNormal.color
-        static let mainButtonText = Asset.Colors.mainButtonText.color
+        static let bold = Asset.background.color
+        static let regular = Asset.regular.color
+        static let active = Asset.active.color
+        static let activePress = Asset.activePress.color
+        static let text = Asset.text.color
+        static let highlighted = Asset.highlighted.color
+        static let error = Asset.error.color
+        static let placeholderGray = Asset.placeholderGray.color
+        static let fieldNormal = Asset.fieldNormal.color
+        static let mainButtonText = Asset.mainButtonText.color
     }
     /// Main colors of application
     enum Main {

--- a/Example/TextFieldsCatalogExample/Resources/Constants/MainTab.swift
+++ b/Example/TextFieldsCatalogExample/Resources/Constants/MainTab.swift
@@ -34,11 +34,11 @@ enum MainTab: Int, CaseIterable {
     var title: String {
         switch self {
         case .catalog:
-            return L10n.Constants.Maintab.catalog
+            return L10n.Constants.MainTab.catalog
         case .example:
-            return L10n.Constants.Maintab.example
+            return L10n.Constants.MainTab.example
         case .info:
-            return L10n.Constants.Maintab.info
+            return L10n.Constants.MainTab.info
         }
     }
 

--- a/Example/TextFieldsCatalogExample/Resources/Images/Assets.swift
+++ b/Example/TextFieldsCatalogExample/Resources/Images/Assets.swift
@@ -1,124 +1,75 @@
-// Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
-#if os(OSX)
-  import AppKit.NSImage
-  typealias AssetColorTypeAlias = NSColor
-  typealias Image = NSImage
-#elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias AssetColorTypeAlias = UIColor
-  typealias Image = UIImage
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
 #endif
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// Deprecated typealiases
+@available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetColorTypeAlias = ColorAsset.Color
+@available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetImageTypeAlias = ImageAsset.Image
 
-@available(*, deprecated, renamed: "ImageAsset")
-typealias AssetType = ImageAsset
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
-struct ImageAsset {
-  fileprivate var name: String
-
-  var image: Image {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: NSImage.Name(name))
-    #elseif os(watchOS)
-    let image = Image(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-struct ColorAsset {
-  fileprivate var name: String
-
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
-}
+// MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-enum Asset {
-  enum Colors {
-    static let active = ColorAsset(name: "active")
-    static let activePress = ColorAsset(name: "activePress")
-    static let background = ColorAsset(name: "background")
-    static let error = ColorAsset(name: "error")
-    static let fieldNormal = ColorAsset(name: "fieldNormal")
-    static let highlighted = ColorAsset(name: "highlighted")
-    static let mainButtonText = ColorAsset(name: "mainButtonText")
-    static let placeholderGray = ColorAsset(name: "placeholderGray")
-    static let regular = ColorAsset(name: "regular")
-    static let text = ColorAsset(name: "text")
+internal enum Asset {
+  internal static let active = ColorAsset(name: "active")
+  internal static let activePress = ColorAsset(name: "activePress")
+  internal static let background = ColorAsset(name: "background")
+  internal static let error = ColorAsset(name: "error")
+  internal static let fieldNormal = ColorAsset(name: "fieldNormal")
+  internal static let highlighted = ColorAsset(name: "highlighted")
+  internal static let mainButtonText = ColorAsset(name: "mainButtonText")
+  internal static let placeholderGray = ColorAsset(name: "placeholderGray")
+  internal static let regular = ColorAsset(name: "regular")
+  internal static let text = ColorAsset(name: "text")
+  internal enum MainTab {
+    internal static let catalog = ImageAsset(name: "MainTab/catalog")
+    internal static let example = ImageAsset(name: "MainTab/example")
+    internal static let info = ImageAsset(name: "MainTab/info")
   }
-  enum MainTab {
-    static let catalog = ImageAsset(name: "MainTab/catalog")
-    static let example = ImageAsset(name: "MainTab/example")
-    static let info = ImageAsset(name: "MainTab/info")
-  }
-  static let close = ImageAsset(name: "close")
-  static let customEyeOff = ImageAsset(name: "customEyeOff")
-  static let customEyeOn = ImageAsset(name: "customEyeOn")
-  static let info = ImageAsset(name: "info")
-  static let qrCode = ImageAsset(name: "qrCode")
-
-  // swiftlint:disable trailing_comma
-  static let allColors: [ColorAsset] = [
-    Colors.active,
-    Colors.activePress,
-    Colors.background,
-    Colors.error,
-    Colors.fieldNormal,
-    Colors.highlighted,
-    Colors.mainButtonText,
-    Colors.placeholderGray,
-    Colors.regular,
-    Colors.text,
-  ]
-  static let allImages: [ImageAsset] = [
-    MainTab.catalog,
-    MainTab.example,
-    MainTab.info,
-    close,
-    customEyeOff,
-    customEyeOn,
-    info,
-    qrCode,
-  ]
-  // swiftlint:enable trailing_comma
-  @available(*, deprecated, renamed: "allImages")
-  static let allValues: [AssetType] = allImages
+  internal static let close = ImageAsset(name: "close")
+  internal static let customEyeOff = ImageAsset(name: "customEyeOff")
+  internal static let customEyeOn = ImageAsset(name: "customEyeOn")
+  internal static let info = ImageAsset(name: "info")
+  internal static let qrCode = ImageAsset(name: "qrCode")
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
-extension Image {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
-  convenience init!(asset: ImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
+// MARK: - Implementation Details
+
+internal final class ColorAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  internal private(set) lazy var color: Color = Color(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 
-extension AssetColorTypeAlias {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+internal extension ColorAsset.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
   convenience init!(asset: ColorAsset) {
-    let bundle = Bundle(for: BundleToken.self)
+    let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
     self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
+    #elseif os(macOS)
     self.init(named: NSColor.Name(asset.name), bundle: bundle)
     #elseif os(watchOS)
     self.init(named: asset.name)
@@ -126,4 +77,55 @@ extension AssetColorTypeAlias {
   }
 }
 
-private final class BundleToken {}
+internal struct ImageAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Image = UIImage
+  #endif
+
+  internal var image: Image {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
+    return result
+  }
+}
+
+internal extension ImageAsset.Image {
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init!(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = BundleToken.bundle
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Example/TextFieldsCatalogExample/Resources/Strings/Strings.swift
+++ b/Example/TextFieldsCatalogExample/Resources/Strings/Strings.swift
@@ -1,248 +1,245 @@
-// Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
-enum L10n {
+// MARK: - Strings
 
-  enum Button {
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+internal enum L10n {
+
+  internal enum Button {
     /// Изменить пресет
-    static let changePreset = L10n.tr("Localizable", "Button.changePreset")
+    internal static let changePreset = L10n.tr("Localizable", "Button.changePreset")
     /// Готово
-    static let done = L10n.tr("Localizable", "Button.done")
+    internal static let done = L10n.tr("Localizable", "Button.done")
     /// Сбросить
-    static let reset = L10n.tr("Localizable", "Button.reset")
+    internal static let reset = L10n.tr("Localizable", "Button.reset")
   }
 
-  enum Constants {
-
-    enum Maintab {
+  internal enum Constants {
+    internal enum MainTab {
       /// Каталог
-      static let catalog = L10n.tr("Localizable", "Constants.MainTab.catalog")
+      internal static let catalog = L10n.tr("Localizable", "Constants.MainTab.catalog")
       /// Примеры
-      static let example = L10n.tr("Localizable", "Constants.MainTab.example")
+      internal static let example = L10n.tr("Localizable", "Constants.MainTab.example")
       /// Инфо
-      static let info = L10n.tr("Localizable", "Constants.MainTab.info")
+      internal static let info = L10n.tr("Localizable", "Constants.MainTab.info")
     }
-
-    enum Sex {
+    internal enum Sex {
       /// Женский
-      static let female = L10n.tr("Localizable", "Constants.Sex.female")
+      internal static let female = L10n.tr("Localizable", "Constants.Sex.female")
       /// Мужской
-      static let male = L10n.tr("Localizable", "Constants.Sex.male")
+      internal static let male = L10n.tr("Localizable", "Constants.Sex.male")
     }
   }
 
-  enum Example {
+  internal enum Example {
     /// Примеры
-    static let title = L10n.tr("Localizable", "Example.title")
+    internal static let title = L10n.tr("Localizable", "Example.title")
   }
 
-  enum Info {
+  internal enum Info {
     /// Данный проект содержит каталог полей ввода, большая часть из которых имеет одинаковый API для взаимодействия с ними. Наличие встроенных валидаторов и форматтеров позволяет широко кастомизировать поведение полей ввода для различных целей: пароль, email, номер телефона и т.п. Более подробно ознакомиться с полями на деле можно открыв экран с примером и посмотреть работу в различных конфигурациях, часть которых из наиболее часто используемых уже включена в проект.\n\n• Если вам необходимо посмотреть на исходный код полей - он находится в дирректории TextFieldsCatalog/TextFields/TextFields.\n• Если вам необходимо посмотреть на исходный код настройки полей в различных конфигурациях - он находится в каталоге TextFieldsCatalog/TextFields/Types and presets/Presets.\n• Если вы - разработчик, и вы хотите добавить новое поле в данный каталог - то необходимо добавить исходный код своего поля ввода в соответствующую дирректорию, добавить новое значение в enum TextFieldType, реализовать свой файл с пресетами и поправить все возникшие ошибки, решение которых приведет к тому, что ваше поле ввода появится в каталоге.
-    static let description = L10n.tr("Localizable", "Info.description")
+    internal static let description = L10n.tr("Localizable", "Info.description")
     /// Инфо
-    static let title = L10n.tr("Localizable", "Info.title")
+    internal static let title = L10n.tr("Localizable", "Info.title")
   }
 
-  enum Main {
+  internal enum Main {
     /// Каталог
-    static let title = L10n.tr("Localizable", "Main.title")
+    internal static let title = L10n.tr("Localizable", "Main.title")
   }
 
-  enum Presets {
-
-    enum Birthday {
+  internal enum Presets {
+    internal enum Birthday {
       /// Пример работы поля для ввода какой либо даты. К примеру, даты рождения. Особенность состоит в том, что для ввода даты используется UIDatePicker.\n\n• Для корректной работы поля необходимо создать кастомное inputView, предоставляемое библиотекой, указав его размер, поле ввода, к которому оно будет относится, а также dateFormat (который по умолчанию установлен в dd.MM.yyyy).\n• При смене даты - текст в поле ввода будет меняться автоматически, в соответствии с установленным dateFormat, а саму дату можно получить, реализовав замыкание onDateChanged.\n• Toolbar кастомизируется, можно поменять текст 'return' кнопки, цвет кнопок, цвет бэкграунда, цвет сепараторов.\n• При установке previous/next input в полях ввода - в тулбаре автоматически появятся кнопки для навигации между полями. При этом создавать inputView необходимо до установки этих значений.\n• Имеется доступ к UIDatePicker, а соответственно, и его настройкам.
-      static let description = L10n.tr("Localizable", "Presets.birthday.description")
+      internal static let description = L10n.tr("Localizable", "Presets.birthday.description")
       /// Вы должны выбрать дату своего рождения
-      static let hint = L10n.tr("Localizable", "Presets.birthday.hint")
+      internal static let hint = L10n.tr("Localizable", "Presets.birthday.hint")
       /// Дата
-      static let name = L10n.tr("Localizable", "Presets.birthday.name")
+      internal static let name = L10n.tr("Localizable", "Presets.birthday.name")
       /// Дата рождения
-      static let placeholder = L10n.tr("Localizable", "Presets.birthday.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.birthday.placeholder")
     }
-
-    enum Cardexpirationdate {
+    internal enum CardExpirationDate {
       /// Пример работы поля для случая ввода срока действия карты.\n\n• Для соответствия содержимого корректному формату - используется форматтер с определенной маской.
-      static let description = L10n.tr("Localizable", "Presets.cardExpirationDate.description")
+      internal static let description = L10n.tr("Localizable", "Presets.cardExpirationDate.description")
       /// Введите месяц и год окончания срока действия
-      static let errorMessage = L10n.tr("Localizable", "Presets.cardExpirationDate.errorMessage")
+      internal static let errorMessage = L10n.tr("Localizable", "Presets.cardExpirationDate.errorMessage")
       /// Срок действия карты
-      static let name = L10n.tr("Localizable", "Presets.cardExpirationDate.name")
+      internal static let name = L10n.tr("Localizable", "Presets.cardExpirationDate.name")
       /// Срок действия карты
-      static let placeholder = L10n.tr("Localizable", "Presets.cardExpirationDate.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.cardExpirationDate.placeholder")
     }
-
-    enum Cardnumber {
+    internal enum CardNumber {
       /// Пример работы поля для случая ввода номера карты.\n\n• Для соответствия содержимого корректному формату - используется форматтер с определенной маской, вставка текста разрешена.\n• Маска поддерживает номера карт от 16 до 19 символов (как пример того, как можно настроить поле для ввода форматированного текста с длиной из некоторого диапазона)
-      static let description = L10n.tr("Localizable", "Presets.cardNumber.description")
+      internal static let description = L10n.tr("Localizable", "Presets.cardNumber.description")
       /// Введите правильно номер Вашей карты
-      static let errorMessage = L10n.tr("Localizable", "Presets.cardNumber.errorMessage")
+      internal static let errorMessage = L10n.tr("Localizable", "Presets.cardNumber.errorMessage")
       /// Номер карты
-      static let name = L10n.tr("Localizable", "Presets.cardNumber.name")
+      internal static let name = L10n.tr("Localizable", "Presets.cardNumber.name")
       /// Номер карты
-      static let placeholder = L10n.tr("Localizable", "Presets.cardNumber.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.cardNumber.placeholder")
     }
-
-    enum Comment {
+    internal enum Comment {
       /// Пример работы поля в случае ввода какого-либо комментария, в данном случае - комментария к доставке.\n\n• Имеется возможность скрыть кнопку очистки содержимого.\n• Есть возможность полностью кастомизировать поле.
-      static let description = L10n.tr("Localizable", "Presets.comment.description")
+      internal static let description = L10n.tr("Localizable", "Presets.comment.description")
       /// Оставьте развернутый комментарий к доставке, он должен быть не менее 30 символов
-      static let errorMessage = L10n.tr("Localizable", "Presets.comment.errorMessage")
+      internal static let errorMessage = L10n.tr("Localizable", "Presets.comment.errorMessage")
       /// Пожалуйста, поделитесь с нами Вашим мнением
-      static let hint = L10n.tr("Localizable", "Presets.comment.hint")
+      internal static let hint = L10n.tr("Localizable", "Presets.comment.hint")
       /// Комментарий
-      static let name = L10n.tr("Localizable", "Presets.comment.name")
+      internal static let name = L10n.tr("Localizable", "Presets.comment.name")
       /// Комментарий к доставке
-      static let placeholder = L10n.tr("Localizable", "Presets.comment.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.comment.placeholder")
     }
-
-    enum Cvc {
+    internal enum Cvc {
       /// Пример работы поля для случая ввода срока действия карты.\n\n• Для соответствия содержимого корректному формату - используется форматтер с определенной маской, вставка текста разрешена.\n• При этом возможно применение обычного валидатора, в котором необходимо задать минимальную и максимальную длину содержимого равной трем, установить соответствующий тип клавиатуры и запретить вставку в поле ввода.
-      static let description = L10n.tr("Localizable", "Presets.cvc.description")
+      internal static let description = L10n.tr("Localizable", "Presets.cvc.description")
       /// CVC-код должен содержать 3 цифры
-      static let errorMessage = L10n.tr("Localizable", "Presets.cvc.errorMessage")
+      internal static let errorMessage = L10n.tr("Localizable", "Presets.cvc.errorMessage")
       /// CVC-код
-      static let name = L10n.tr("Localizable", "Presets.cvc.name")
+      internal static let name = L10n.tr("Localizable", "Presets.cvc.name")
       /// CVC
-      static let placeholder = L10n.tr("Localizable", "Presets.cvc.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.cvc.placeholder")
     }
-
-    enum Email {
+    internal enum Email {
       /// Пример работы поля для случая ввода email-адреса.\n\n• Для корректной работы достаточно только изменить тип клавиатуры и задать валидатор, не позволяющий оставлять поле пустым и содержащий регулярное выражение.
-      static let description = L10n.tr("Localizable", "Presets.email.description")
+      internal static let description = L10n.tr("Localizable", "Presets.email.description")
       /// Email
-      static let name = L10n.tr("Localizable", "Presets.email.name")
+      internal static let name = L10n.tr("Localizable", "Presets.email.name")
       /// Email
-      static let placeholder = L10n.tr("Localizable", "Presets.email.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.email.placeholder")
     }
-
-    enum Name {
+    internal enum Name {
       /// Пример поля ввода, в котором установлена маска с кастомной нотацией.\n\n• Поле имеет возможность установить маску для ввода, к примеру маску номера телефона, но есть и еще одна возможность использования: можно создать свою кастомную нотацию для маски (в частности, здесь применена кастомная нотация, где в маске символом R обозначается символ, соответствующий букве русского алфавита и пробелу).\n• Таким образом, в это поле нельзя ввести ничего, кроме пробела и букв русского алфавита.\n• В качестве приятного бонуса - пример, как можно обрезать пробелы в начале и конце строки при стнятии фокуса.
-      static let description = L10n.tr("Localizable", "Presets.name.description")
+      internal static let description = L10n.tr("Localizable", "Presets.name.description")
       /// Используйте только русские буквы
-      static let hint = L10n.tr("Localizable", "Presets.name.hint")
+      internal static let hint = L10n.tr("Localizable", "Presets.name.hint")
       /// Имя должно быть не более 20 символов
-      static let largeTextError = L10n.tr("Localizable", "Presets.name.largeTextError")
+      internal static let largeTextError = L10n.tr("Localizable", "Presets.name.largeTextError")
       /// Имя
-      static let name = L10n.tr("Localizable", "Presets.name.name")
+      internal static let name = L10n.tr("Localizable", "Presets.name.name")
       /// Используйте только русские буквы
-      static let notValidError = L10n.tr("Localizable", "Presets.name.notValidError")
+      internal static let notValidError = L10n.tr("Localizable", "Presets.name.notValidError")
       /// Имя
-      static let placeholder = L10n.tr("Localizable", "Presets.name.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.name.placeholder")
     }
-
-    enum Password {
+    internal enum Password {
       /// Пример кастомизации и работы поля для ввода пароля.\n\n• Максимальная длина пароля - 20 символов (возможно сделать более изящное решение, изменив маску, что приведет к тому, что пользователь не введет более 20 символов в принципе).\n• Задана маска, которая не позволяет вводить пробелы и переносы строки.\n• Запрещена вставка символов.\n• Задано регулярное выражение: корректный пароль состоит из не менее 8 символов, букв латинского алфавита, хотя бы одной маленькой, одной большой буквы и одной цифры.\n\nВажная особенность: rightView у внутреннего текстфилда отсутствует, чтобы предотвратить наложение иконки с глазом поверх стрелки в режиме caps lock.\n\nЕще одна особенность: добавлен код, предотвращающий полное удаление содержимого при повторном вводе в поле ввода (дефолтное поведение, связанное с secureMode).
-      static let description = L10n.tr("Localizable", "Presets.password.description")
+      internal static let description = L10n.tr("Localizable", "Presets.password.description")
       /// Пароль должен содержать буквы латинского алфавита, хотя бы одну маленькую, одну большую буквы и быть длинною не менее 8 символов
-      static let hint = L10n.tr("Localizable", "Presets.password.hint")
+      internal static let hint = L10n.tr("Localizable", "Presets.password.hint")
       /// Пароль должен содержать не более %@ символов
-      static func largeErrorText(_ p1: String) -> String {
-        return L10n.tr("Localizable", "Presets.password.largeErrorText", p1)
+      internal static func largeErrorText(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "Presets.password.largeErrorText", String(describing: p1))
       }
       /// Пароль
-      static let name = L10n.tr("Localizable", "Presets.password.name")
+      internal static let name = L10n.tr("Localizable", "Presets.password.name")
       /// Пароль
-      static let placeholder = L10n.tr("Localizable", "Presets.password.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.password.placeholder")
       /// Пароль слишком короткий
-      static let shortErrorText = L10n.tr("Localizable", "Presets.password.shortErrorText")
+      internal static let shortErrorText = L10n.tr("Localizable", "Presets.password.shortErrorText")
       /// Текст возможной подсказки
-      static let shortHint = L10n.tr("Localizable", "Presets.password.shortHint")
+      internal static let shortHint = L10n.tr("Localizable", "Presets.password.shortHint")
     }
-
-    enum Phone {
+    internal enum Phone {
       /// Пример работы поля для случая ввода номера телефона.\n\n• Отличный пример совместного использования валидатора и форматтера. Форматтер позволяет задать маску под номер телефона, валидатор же проверяет на полноту его ввода.\n\nВ данном кейсе представлен пример ввода телефона в российском формате.
-      static let description = L10n.tr("Localizable", "Presets.phone.description")
+      internal static let description = L10n.tr("Localizable", "Presets.phone.description")
       /// Номер телефона должен содержать 10 цифр
-      static let errorMessage = L10n.tr("Localizable", "Presets.phone.errorMessage")
+      internal static let errorMessage = L10n.tr("Localizable", "Presets.phone.errorMessage")
       /// Номер телефона
-      static let name = L10n.tr("Localizable", "Presets.phone.name")
+      internal static let name = L10n.tr("Localizable", "Presets.phone.name")
       /// Номер телефона
-      static let placeholder = L10n.tr("Localizable", "Presets.phone.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.phone.placeholder")
     }
-
-    enum Qrcode {
+    internal enum QrCode {
       /// Пример работы поля с кастомной кнопкой справа.\n\n• Контент для кнопки устанавливается вместе с модом самого текстового поля (метод setTextFieldMode).\n• Есть возможность указать необходимую иконку для кнопки, а также ее цвет в нормальном состоянии и состояниях highlighted/selected
-      static let description = L10n.tr("Localizable", "Presets.qrCode.description")
+      internal static let description = L10n.tr("Localizable", "Presets.qrCode.description")
       /// Можно считать QR-код с помощью камеры
-      static let hint = L10n.tr("Localizable", "Presets.qrCode.hint")
+      internal static let hint = L10n.tr("Localizable", "Presets.qrCode.hint")
       /// QR-код
-      static let name = L10n.tr("Localizable", "Presets.qrCode.name")
+      internal static let name = L10n.tr("Localizable", "Presets.qrCode.name")
       /// Введите QR-код
-      static let placeholder = L10n.tr("Localizable", "Presets.qrCode.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.qrCode.placeholder")
     }
-
-    enum Sex {
+    internal enum Sex {
       /// Пример работы поля для выбора какого-то значения из заранее заготовленного списка. Для более простого выбора используется барабан (UIPickerView).\n\n• Для корректной работы поля необходимо создать кастомное inputView, предоставляемое библиотекой, указав его размер, поле ввода, к которому оно будет относится, а также передать список необходимых к отображению значений.\n• При смене значения - текст в поле ввода будет меняться автоматически.\n• Toolbar кастомизируется, можно поменять текст 'return' кнопки, цвет кнопок, цвет бэкграунда, цвет сепараторов.\n• При установке previous/next input в полях ввода - в тулбаре автоматически появятся кнопки для навигации между полями. При этом создавать inputView необходимо до установки этих значений.
-      static let description = L10n.tr("Localizable", "Presets.sex.description")
+      internal static let description = L10n.tr("Localizable", "Presets.sex.description")
       /// Вы должны определиться со своим полом
-      static let hint = L10n.tr("Localizable", "Presets.sex.hint")
+      internal static let hint = L10n.tr("Localizable", "Presets.sex.hint")
       /// Пол
-      static let name = L10n.tr("Localizable", "Presets.sex.name")
+      internal static let name = L10n.tr("Localizable", "Presets.sex.name")
       /// Пол
-      static let placeholder = L10n.tr("Localizable", "Presets.sex.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.sex.placeholder")
     }
-
-    enum Sum {
+    internal enum Sum {
       /// Пример работы поля для ввода суммы.\n\n• Не самая простая его реализация.\n• Имеет три плейсхолдера, один - статический, второй - нативный. Третий же - кастомный, отвечает за символ валюты, перемещающийся вслед за текстом.\n• При ввода какого-либо валидного значения - оно устанавливается в нативный плейсхолдер.\n• Имеется обработка разных граничных значений при ввода, а также при снятии фокуса.\n• Коряво работает перемещение каретки ввода при добавлении символов или их удалении, если они проводятся не в конце вводимой строки, простите :(
-      static let description = L10n.tr("Localizable", "Presets.sum.description")
+      internal static let description = L10n.tr("Localizable", "Presets.sum.description")
       /// Сумма
-      static let name = L10n.tr("Localizable", "Presets.sum.name")
+      internal static let name = L10n.tr("Localizable", "Presets.sum.name")
       /// Сумма
-      static let placeholder = L10n.tr("Localizable", "Presets.sum.placeholder")
+      internal static let placeholder = L10n.tr("Localizable", "Presets.sum.placeholder")
     }
   }
 
-  enum Textfieldtype {
-
-    enum Box {
+  internal enum TextFieldType {
+    internal enum Box {
       /// • Границы поля ввода скруглены и подсвечены.\n• Имеется плейсхолдер над полем ввода.\n• Информационное-сообщение или сообщение об ошибке внизу, в одну строку.\n• Кастомизируется под ввод пароля.\n• Поддержка валидаторов и форматтеров.
-      static let description = L10n.tr("Localizable", "TextFieldType.Box.description")
+      internal static let description = L10n.tr("Localizable", "TextFieldType.Box.description")
       /// Поле ввода с обводкой
-      static let title = L10n.tr("Localizable", "TextFieldType.Box.title")
+      internal static let title = L10n.tr("Localizable", "TextFieldType.Box.title")
     }
-
-    enum Customunderlined {
+    internal enum CustomUnderlined {
       /// • То же самое, что и поле ввода с подчеркиванием, но кастомизированное.\n• Отсутствует лейбл с подсказкой/ошибкой.
-      static let description = L10n.tr("Localizable", "TextFieldType.CustomUnderlined.description")
+      internal static let description = L10n.tr("Localizable", "TextFieldType.CustomUnderlined.description")
       /// Кастомизированое поле ввода с подчеркивание
-      static let title = L10n.tr("Localizable", "TextFieldType.CustomUnderlined.title")
+      internal static let title = L10n.tr("Localizable", "TextFieldType.CustomUnderlined.title")
     }
-
-    enum Sumtextfield {
+    internal enum SumTextField {
       /// • Пример кастомизации полей для случая ввода суммы.\n• Имеет целых три плейхолдера, один из которых - кастомный.\n• Логика для обработки введенных значений не привязана к библиотеке, реализована в качестве примера.\n• Помимо прочего - введенный текст уменьшается, если не влезает в границы поля.
-      static let description = L10n.tr("Localizable", "TextFieldType.SumTextField.description")
+      internal static let description = L10n.tr("Localizable", "TextFieldType.SumTextField.description")
       /// Поле ввода суммы
-      static let title = L10n.tr("Localizable", "TextFieldType.SumTextField.title")
+      internal static let title = L10n.tr("Localizable", "TextFieldType.SumTextField.title")
     }
-
-    enum Underlined {
+    internal enum Underlined {
       /// • Под полем ввода присутствует линия.\n• Плейсхолдер выполнен как CATextLayer, что позволяет анимационно изменять его кегль, цвет и позицию при переходе между состояниями.\n• Кастомизируется под ввод пароля.\n• Информационное-сообщение или сообщение об ошибке внизу, в одну строку.\n• Поддержка валидаторов и форматтеров.
-      static let description = L10n.tr("Localizable", "TextFieldType.Underlined.description")
+      internal static let description = L10n.tr("Localizable", "TextFieldType.Underlined.description")
       /// Подчеркнутое поле ввода
-      static let title = L10n.tr("Localizable", "TextFieldType.Underlined.title")
+      internal static let title = L10n.tr("Localizable", "TextFieldType.Underlined.title")
     }
-
-    enum Underlinedtextview {
+    internal enum UnderlinedTextView {
       /// • По дизайну - то же самое, что и просто подчеркнутое поле ввода.\n• Имеет практически все его возможности, за некоторым исключением (нет тех методов, которые данному полю в принципе не нужны).\n• В основном используется для полей ввода комментариев - то есть в тех местах, где текст будет явно превышать одну строку. Именно по этому данное поле - пока что единственная в этой библиотеке обертка именно над UITextView, а не UITextField\n• Имеется возможность показа/скрытия кнопки очистки содержимого.
-      static let description = L10n.tr("Localizable", "TextFieldType.UnderlinedTextView.description")
+      internal static let description = L10n.tr("Localizable", "TextFieldType.UnderlinedTextView.description")
       /// UITextView с подчеркиванием
-      static let title = L10n.tr("Localizable", "TextFieldType.UnderlinedTextView.title")
+      internal static let title = L10n.tr("Localizable", "TextFieldType.UnderlinedTextView.title")
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
 
-private final class BundleToken {}
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/SumTextField/CurrencyPlaceholderService.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/SumTextField/CurrencyPlaceholderService.swift
@@ -7,6 +7,7 @@
 //
 
 import TextFieldsCatalog
+import UIKit
 
 final class CurrencyPlaceholderService: AbstractPlaceholderService {
 

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -7,6 +7,7 @@
 //
 
 import TextFieldsCatalog
+import UIKit
 
 extension UnderlinedTextField {
 

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
@@ -32,13 +32,13 @@ enum UnderlinedFieldPreset: CaseIterable, AppliedPreset {
         case .phone:
             return L10n.Presets.Phone.name
         case .cardExpirationDate:
-            return L10n.Presets.Cardexpirationdate.name
+            return L10n.Presets.CardExpirationDate.name
         case .cvc:
             return L10n.Presets.Cvc.name
         case .cardNumber:
-            return L10n.Presets.Cardnumber.name
+            return L10n.Presets.CardNumber.name
         case .qrCode:
-            return L10n.Presets.Qrcode.name
+            return L10n.Presets.QrCode.name
         case .birthday:
             return L10n.Presets.Birthday.name
         case .sex:
@@ -57,13 +57,13 @@ enum UnderlinedFieldPreset: CaseIterable, AppliedPreset {
         case .phone:
             return L10n.Presets.Phone.description
         case .cardExpirationDate:
-            return L10n.Presets.Cardexpirationdate.description
+            return L10n.Presets.CardExpirationDate.description
         case .cvc:
             return L10n.Presets.Cvc.description
         case .cardNumber:
-            return L10n.Presets.Cardnumber.description
+            return L10n.Presets.CardNumber.description
         case .qrCode:
-            return L10n.Presets.Qrcode.description
+            return L10n.Presets.QrCode.description
         case .birthday:
             return L10n.Presets.Birthday.description
         case .sex:
@@ -162,11 +162,11 @@ private extension UnderlinedFieldPreset {
     }
 
     func tuneFieldForCardExpirationDate(_ textField: UnderlinedTextField) {
-        textField.placeholder = L10n.Presets.Cardexpirationdate.placeholder
+        textField.placeholder = L10n.Presets.CardExpirationDate.placeholder
         textField.validator = TextFieldValidator(minLength: 5,
                                                  maxLength: nil,
                                                  regex: nil,
-                                                 globalErrorMessage: L10n.Presets.Cardexpirationdate.errorMessage)
+                                                 globalErrorMessage: L10n.Presets.CardExpirationDate.errorMessage)
         textField.maskFormatter = MaskTextFieldFormatter(mask: FormatterMasks.cardExpirationDate)
         textField.field.autocorrectionType = .no
         textField.field.keyboardType = .numberPad
@@ -185,23 +185,23 @@ private extension UnderlinedFieldPreset {
     }
 
     func tuneFieldForCardNumber(_ textField: UnderlinedTextField) {
-        textField.placeholder = L10n.Presets.Cardnumber.placeholder
+        textField.placeholder = L10n.Presets.CardNumber.placeholder
         textField.validator = TextFieldValidator(minLength: 19,
                                                  maxLength: nil,
                                                  regex: nil,
-                                                 globalErrorMessage: L10n.Presets.Cardnumber.errorMessage)
+                                                 globalErrorMessage: L10n.Presets.CardNumber.errorMessage)
         textField.maskFormatter = MaskTextFieldFormatter(mask: FormatterMasks.cardNumber)
         textField.field.autocorrectionType = .no
         textField.field.keyboardType = .numberPad
     }
 
     func tuneFieldForQRCode(_ textField: UnderlinedTextField) {
-        textField.placeholder = L10n.Presets.Qrcode.placeholder
+        textField.placeholder = L10n.Presets.QrCode.placeholder
         textField.validator = TextFieldValidator(minLength: 10, maxLength: 10, regex: nil)
         textField.field.autocorrectionType = .no
         textField.field.keyboardType = .asciiCapable
         textField.maxLength = 10
-        textField.setup(hint: L10n.Presets.Qrcode.hint)
+        textField.setup(hint: L10n.Presets.QrCode.hint)
 
         let actionButtonConfig = ActionButtonConfiguration(image: UIImage(asset: Asset.qrCode),
                                                            normalColor: Color.Button.active,

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/TextFieldType.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/TextFieldType.swift
@@ -19,30 +19,30 @@ enum TextFieldType: CaseIterable {
     var title: String {
         switch self {
         case .underlined:
-            return L10n.Textfieldtype.Underlined.title
+            return L10n.TextFieldType.Underlined.title
         case .box:
-            return L10n.Textfieldtype.Box.title
+            return L10n.TextFieldType.Box.title
         case .customUnderlined:
-            return L10n.Textfieldtype.Customunderlined.title
+            return L10n.TextFieldType.CustomUnderlined.title
         case .underlinedTextView:
-            return L10n.Textfieldtype.Underlinedtextview.title
+            return L10n.TextFieldType.UnderlinedTextView.title
         case .sumTextField:
-            return L10n.Textfieldtype.Sumtextfield.title
+            return L10n.TextFieldType.SumTextField.title
         }
     }
 
     var description: String {
         switch self {
         case .underlined:
-            return L10n.Textfieldtype.Underlined.description
+            return L10n.TextFieldType.Underlined.description
         case .box:
-            return L10n.Textfieldtype.Box.description
+            return L10n.TextFieldType.Box.description
         case .customUnderlined:
-            return L10n.Textfieldtype.Customunderlined.description
+            return L10n.TextFieldType.CustomUnderlined.description
         case .underlinedTextView:
-            return L10n.Textfieldtype.Underlinedtextview.description
+            return L10n.TextFieldType.UnderlinedTextView.description
         case .sumTextField:
-            return L10n.Textfieldtype.Sumtextfield.description
+            return L10n.TextFieldType.SumTextField.description
         }
     }
 

--- a/Example/swiftgen.yml
+++ b/Example/swiftgen.yml
@@ -1,8 +1,12 @@
 xcassets:
-  paths: TextFieldsCatalogExample/Resources/Images/Assets.xcassets
-  templateName: swift4
-  output: TextFieldsCatalogExample/Resources/Images/Assets.swift
+  inputs:
+    - TextFieldsCatalogExample/Resources/Images/Assets.xcassets
+  outputs:
+    - templateName: swift4
+      output: TextFieldsCatalogExample/Resources/Images/Assets.swift
+
 strings:
-  paths: TextFieldsCatalogExample/Resources/Strings/en.lproj/Localizable.strings
-  templateName: structured-swift4
-  output: TextFieldsCatalogExample/Resources/Strings/Strings.swift
+  inputs: TextFieldsCatalogExample/Resources/Strings/en.lproj/Localizable.strings
+  outputs:
+    - templateName: structured-swift4
+      output: TextFieldsCatalogExample/Resources/Strings/Strings.swift

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "InputMask",
+        "repositoryURL": "https://github.com/RedMadRobot/input-mask-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "f78e7c8fe6f0f2b6512b69006ec595aa1224592f",
+          "version": "6.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,59 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TextFieldsCatalog",
+    defaultLocalization: "en",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "TextFieldsCatalog",
+            targets: ["TextFieldsCatalog"])
+    ],
+    dependencies: [
+        .package(
+            name: "InputMask",
+            url: "https://github.com/RedMadRobot/input-mask-ios.git",
+            .exact("6.0.0")
+        )
+    ],
+    targets: [
+        .target(
+            name: "TextFieldsCatalog",
+            dependencies: ["InputMask"],
+            path: "TextFieldsCatalog",
+            exclude: [
+                "Info.plist"
+            ],
+            resources: [
+                .process("Resources/Images/leftArrow@2x.png"),
+                .process("Resources/Images/leftArrow@3x.png"),
+                .process("Resources/Images/close@3x.png"),
+                .process("Resources/Images/eyeOff.png"),
+                .process("Resources/Images/eyeOff@3x.png"),
+                .process("Resources/Images/eyeOn.png"),
+                .process("Resources/Images/close@2x.png"),
+                .process("Resources/Images/eyeOff@2x.png"),
+                .process("Resources/Images/rightArrow@2x.png"),
+                .process("Resources/Images/rightArrow.png"),
+                .process("Resources/Images/leftArrow.png"),
+                .process("Resources/Images/rightArrow@3x.png"),
+                .process("Resources/Images/eyeOn@3x.png"),
+                .process("Resources/Images/eyeOn@2x.png"),
+                .process("Resources/Images/close.png")
+            ]
+        ),
+        .testTarget(
+            name: "TextFieldsCatalogTests",
+            dependencies: ["TextFieldsCatalog"],
+            path: "TextFieldsCatalogTests",
+            exclude: [
+                "Info.plist"
+            ]
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "TextFieldsCatalog",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v10)
     ],
     products: [
         .library(
@@ -30,21 +30,21 @@ let package = Package(
                 "Info.plist"
             ],
             resources: [
-                .process("Resources/Images/leftArrow@2x.png"),
-                .process("Resources/Images/leftArrow@3x.png"),
+                .process("Resources/Images/close.png"),
+                .process("Resources/Images/close@2x.png"),
                 .process("Resources/Images/close@3x.png"),
                 .process("Resources/Images/eyeOff.png"),
+                .process("Resources/Images/eyeOff@2x.png"),
                 .process("Resources/Images/eyeOff@3x.png"),
                 .process("Resources/Images/eyeOn.png"),
-                .process("Resources/Images/close@2x.png"),
-                .process("Resources/Images/eyeOff@2x.png"),
-                .process("Resources/Images/rightArrow@2x.png"),
-                .process("Resources/Images/rightArrow.png"),
-                .process("Resources/Images/leftArrow.png"),
-                .process("Resources/Images/rightArrow@3x.png"),
-                .process("Resources/Images/eyeOn@3x.png"),
                 .process("Resources/Images/eyeOn@2x.png"),
-                .process("Resources/Images/close.png")
+                .process("Resources/Images/eyeOn@3x.png"),
+                .process("Resources/Images/leftArrow.png"),
+                .process("Resources/Images/leftArrow@2x.png"),
+                .process("Resources/Images/leftArrow@3x.png"),
+                .process("Resources/Images/rightArrow.png"),
+                .process("Resources/Images/rightArrow@2x.png"),
+                .process("Resources/Images/rightArrow@3x.png")
             ]
         ),
         .testTarget(

--- a/Podfile
+++ b/Podfile
@@ -3,13 +3,13 @@ platform :ios, '10.0'
 inhibit_all_warnings!
 
 def utils
-    pod 'SwiftGen', '5.2.1'
-    pod 'SwiftLint', '0.29.4'
+    pod 'SwiftGen', '6.4.0'
+    pod 'SwiftLint', '0.41.0'
 end
 
 def common_pods
     utils
-    pod 'InputMask', '4.0.2'
+    pod 'InputMask', '6.0.0'
 end
 
 target 'TextFieldsCatalog' do

--- a/TextFieldsCatalog.podspec
+++ b/TextFieldsCatalog.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
 
 
   s.framework  = "UIKit"
-  s.dependency "InputMask", '4.0.2'
+  s.dependency "InputMask", '6.0.0'
 
 end

--- a/TextFieldsCatalog/Library/BaseClasses/InnerDesignableView.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerDesignableView.swift
@@ -30,7 +30,19 @@ open class InnerDesignableView: UIView {
     }
 
     func setup() -> UIView? {
-        let view = Bundle(for: type(of: self)).loadNibNamed(self.nameOfClass, owner: self, options: nil)?.first as? UIView
+        let bundle: Bundle
+        #if SWIFT_PACKAGE
+        if Bundle.module.path(forResource: self.nameOfClass, ofType: "nib") != nil {
+            bundle = Bundle.module
+        } else {
+            bundle = Bundle(for: type(of: self))
+        }
+        #else
+        bundle = Bundle(for: type(of: self))
+        #endif
+
+        bundle.load()
+        let view = bundle.loadNibNamed(self.nameOfClass, owner: self, options: nil)?.first as? UIView
         if let v = view {
             addSubview(v)
             v.frame = self.bounds

--- a/TextFieldsCatalog/Library/BaseClasses/InnerDesignableView.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerDesignableView.swift
@@ -30,12 +30,18 @@ open class InnerDesignableView: UIView {
     }
 
     func setup() -> UIView? {
-        let bundle: Bundle
+        var bundle: Bundle
         #if SWIFT_PACKAGE
         if Bundle.module.path(forResource: self.nameOfClass, ofType: "nib") != nil {
             bundle = Bundle.module
         } else {
             bundle = Bundle(for: type(of: self))
+        }
+
+        // helper for TextFieldCatalog package use in different package with xibs
+        if bundle.path(forResource: self.nameOfClass, ofType: "nib") == nil,
+           let resourceBundle = getResourcesBundle(for: bundle) {
+            bundle = resourceBundle
         }
         #else
         bundle = Bundle(for: type(of: self))
@@ -48,6 +54,15 @@ open class InnerDesignableView: UIView {
             v.frame = self.bounds
         }
         return view
+    }
+
+    // MARK: - Private methods
+
+    private func getResourcesBundle(for bundle: Bundle) -> Bundle? {
+        let packageName = NSStringFromClass(type(of: self)).components(separatedBy: ".").first ?? ""
+        let bundleName = packageName + "_" + packageName + ".bundle"
+        let resource = bundle.resourcePath ?? ""
+        return Bundle(path: resource + "/" + bundleName)
     }
 
 }

--- a/TextFieldsCatalog/Library/Extensions/UIKit/UITextField.swift
+++ b/TextFieldsCatalog/Library/Extensions/UIKit/UITextField.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 extension UITextField {
 
     /// Returns `true` if input text is empty

--- a/TextFieldsCatalog/Library/Extensions/UIKit/UITextView.swift
+++ b/TextFieldsCatalog/Library/Extensions/UIKit/UITextView.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 extension UITextView {
 
     /// Returns `true` if input text is empty

--- a/TextFieldsCatalog/Library/Protocols/TextField/RespondableField.swift
+++ b/TextFieldsCatalog/Library/Protocols/TextField/RespondableField.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 /**
  Abstract protocol that give you ability to control under responder chain for text fields.
  */

--- a/TextFieldsCatalog/Library/Protocols/ToolBarInterface.swift
+++ b/TextFieldsCatalog/Library/Protocols/ToolBarInterface.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 /// Abstract protocol for fields input accessory views.
 /// You can add buttons to switch between input fields, guidedField will help you with this.
 /// Or you can ignore this field and create your own custom toolbar!

--- a/TextFieldsCatalog/Library/Utils/AssetManager.swift
+++ b/TextFieldsCatalog/Library/Utils/AssetManager.swift
@@ -7,13 +7,18 @@
 //
 
 import Foundation
+import UIKit
 
 final class AssetManager {
 
     func getImage(_ name: String) -> UIImage {
         let traitCollection = UITraitCollection(displayScale: UIScreen.main.scale)
-        var bundle = Bundle(for: AssetManager.self)
-
+        var bundle: Bundle
+        #if SWIFT_PACKAGE
+        bundle = Bundle.module
+        #else
+        bundle = Bundle(for: AssetManager.self)
+        #endif
         if let resource = bundle.resourcePath, let resourceBundle = Bundle(path: resource + "/TextFieldsCatalog.bundle") {
             bundle = resourceBundle
         }

--- a/TextFieldsCatalog/Library/Utils/MaskTextFieldFormatter.swift
+++ b/TextFieldsCatalog/Library/Utils/MaskTextFieldFormatter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import InputMask
+import UIKit
 
 /// Special formatter for input field with mask (work only with text field)
 public final class MaskTextFieldFormatter: NSObject {
@@ -15,9 +16,9 @@ public final class MaskTextFieldFormatter: NSObject {
     // MARK: - Properties
 
     /// Error message for case, when user leave empty text field
-    public var emptyStringErrorMessage: String = L10n.Errors.Textfield.empty
+    public var emptyStringErrorMessage: String = L10n.Errors.TextField.empty
     /// Error message for case, when user leave incorrect text field
-    public var incorrectStringErrorMessage: String = L10n.Errors.Textfield.notValid
+    public var incorrectStringErrorMessage: String = L10n.Errors.TextField.notValid
 
     // MARK: - Private Properties
 
@@ -66,7 +67,9 @@ public final class MaskTextFieldFormatter: NSObject {
         guard let text = string else {
             return nil
         }
-        let result = maskedDelegate.primaryMask.apply(toText: CaretString(string: text, caretPosition: text.endIndex), autocomplete: true)
+        let result = maskedDelegate.primaryMask.apply(
+            toText: CaretString(string: text, caretPosition: text.endIndex, caretGravity: .forward(autocomplete: true))
+        )
         return result.formattedText.string
     }
 

--- a/TextFieldsCatalog/Library/Utils/TextFieldValidator.swift
+++ b/TextFieldsCatalog/Library/Utils/TextFieldValidator.swift
@@ -19,11 +19,11 @@ public final class TextFieldValidator {
     // MARK: - Constants
 
     private enum Constant {
-        static let emptyErrorText = L10n.Errors.Textfield.empty
+        static let emptyErrorText = L10n.Errors.TextField.empty
         static func shortErrorText(minLength: Int) -> String {
-            return L10n.Errors.Textfield.short(String(minLength))
+            return L10n.Errors.TextField.short(String(minLength))
         }
-        static let notValidErrorText = L10n.Errors.Textfield.notValid
+        static let notValidErrorText = L10n.Errors.TextField.notValid
     }
 
     // MARK: - Private Properties

--- a/TextFieldsCatalog/Resources/Constants/Internal/AnimationTime.swift
+++ b/TextFieldsCatalog/Resources/Constants/Internal/AnimationTime.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import Foundation
+
 enum AnimationTime {
     static let `default`: TimeInterval = 0.3
 }

--- a/TextFieldsCatalog/Resources/Strings/Strings.swift
+++ b/TextFieldsCatalog/Resources/Strings/Strings.swift
@@ -1,39 +1,54 @@
-// Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
-enum L10n {
+// MARK: - Strings
 
-  enum Button {
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+public enum L10n {
+
+  public enum Button {
     /// Done
-    static let done = L10n.tr("Localizable", "Button.Done")
+    public static let done = L10n.tr("Localizable", "Button.Done")
   }
 
-  enum Errors {
-
-    enum Textfield {
+  public enum Errors {
+    public enum TextField {
       /// Field must be filled
-      static let empty = L10n.tr("Localizable", "Errors.TextField.empty")
+      public static let empty = L10n.tr("Localizable", "Errors.TextField.empty")
       /// Wrong format
-      static let notValid = L10n.tr("Localizable", "Errors.TextField.notValid")
+      public static let notValid = L10n.tr("Localizable", "Errors.TextField.notValid")
       /// The field must contain at least %@ characters.
-      static func short(_ p1: String) -> String {
-        return L10n.tr("Localizable", "Errors.TextField.short", p1)
+      public static func short(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "Errors.TextField.short", String(describing: p1))
       }
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
 
-private final class BundleToken {}
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type

--- a/TextFieldsCatalog/TextFields/Configuration/FlexibleHeightPolicy.swift
+++ b/TextFieldsCatalog/TextFields/Configuration/FlexibleHeightPolicy.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 public struct FlexibleHeightPolicy {
 
     // MARK: - Properties

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/FieldService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/FieldService.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import Foundation
+import UIKit
+
 final class FieldService {
 
     // MARK: - Private Properties

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import Foundation
+import UIKit
+
 final class HintService {
 
     // MARK: - Private Properties

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/LineService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/LineService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 final class LineService {
 
     // MARK: - Nested Types

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/Placeholder/FloatingPlaceholderService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/Placeholder/FloatingPlaceholderService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 /**
  Default variant of placeholder service which implements logic of `floating`-placeholder.
 

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/Placeholder/NativePlaceholderService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/Placeholder/NativePlaceholderService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 /**
  Default variant of placeholder service which implements logic of `native`-placeholder.
 

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/Placeholder/StaticPlaceholderService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/Placeholder/StaticPlaceholderService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 /**
  Default variant of placeholder service which implements logic of `static`-placeholder.
 

--- a/TextFieldsCatalog/TextFields/Services/Support/AbstractPlaceholderService.swift
+++ b/TextFieldsCatalog/TextFields/Services/Support/AbstractPlaceholderService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 /**
  Protocol for abstract service, which contains logic for drawing placeholder.
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 Александр Чаусов. All rights reserved.
 //
 
-import UIKit
 import InputMask
+import UIKit
 
 /// Class for custom textField. Contains UITextFiled, top floating placeholder, underline line under textField and bottom label with some info.
 /// Standart height equals 77.

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.xib
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UnderlinedTextField" customModule="TextFieldsCatalog" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UnderlinedTextField" customModule="TextFieldsCatalog">
             <connections>
                 <outlet property="actionButton" destination="hZM-WG-Dn7" id="z5n-qb-fPk"/>
                 <outlet property="hintLabel" destination="B8b-xj-ysW" id="w41-fK-Sop"/>
@@ -22,12 +20,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nxT-nZ-3cy" customClass="InnerTextField" customModule="TextFieldsCatalog" customModuleProvider="target">
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nxT-nZ-3cy" customClass="InnerTextField" customModule="TextFieldsCatalog">
                     <rect key="frame" x="16" y="18" width="288" height="30"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="ojM-dv-27B"/>
                     </constraints>
-                    <nil key="textColor"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits"/>
                 </textField>
@@ -51,6 +48,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="B8b-xj-ysW" secondAttribute="trailing" constant="16" id="2nU-Fg-biu"/>
                 <constraint firstItem="B8b-xj-ysW" firstAttribute="top" secondItem="nxT-nZ-3cy" secondAttribute="bottom" constant="9" id="42h-wY-1Km"/>
@@ -62,7 +60,6 @@
                 <constraint firstItem="nxT-nZ-3cy" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="18" id="ssf-sV-Hvp"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="46.875" y="54.401408450704224"/>
         </view>
     </objects>

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.xib
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UnderlinedTextView" customModule="TextFieldsCatalog" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UnderlinedTextView" customModule="TextFieldsCatalog">
             <connections>
                 <outlet property="clearButton" destination="hDZ-Nk-vhL" id="chR-eD-Shd"/>
                 <outlet property="hintLabel" destination="ZCF-Sk-dJU" id="JZE-Q0-jBY"/>
@@ -53,6 +53,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
                 <constraint firstItem="mpb-Kh-o2r" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="0bX-As-kQt"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="hDZ-Nk-vhL" secondAttribute="trailing" id="Jbq-an-BfH"/>
@@ -64,7 +65,6 @@
                 <constraint firstItem="mpb-Kh-o2r" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="28" id="yWg-X3-yZt"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="131.25" y="-106.69014084507042"/>
         </view>
     </objects>

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -1,4 +1,7 @@
 strings:
-  paths: TextFieldsCatalog/Resources/Strings/en.lproj/Localizable.strings
-  templateName: structured-swift4
-  output: TextFieldsCatalog/Resources/Strings/Strings.swift
+  inputs: TextFieldsCatalog/Resources/Strings/en.lproj/Localizable.strings
+  outputs:
+    - templateName: structured-swift4
+      params:
+        publicAccess: true
+      output: TextFieldsCatalog/Resources/Strings/Strings.swift


### PR DESCRIPTION
Ветка направлена не на `dev/version-1` - так как разработка шла от нее

**Что сделано**

- Добавлена поддержка spm 
- Для этого подняты версии `InputMask` (должна тоже уметь в spm), `swiftGen` (чтобы встроенные шаблоны поддерживали `Bundle.module`) и `swiftLint` (чтобы дружили с обновленным `swiftGen`)
- в travis добавлена новая команда на сборку пакета для ios

**На что обратить внимание**

- Обновлен код под новые версии зависимых либ (включая swiftgen.yml)
- `swift build` работать не будет так как у `InputMask` не прописана платформа и по умолчанию сборка идет на macOS 
- по умолчанию в пакет попадает все что лежит в одной папке с манифестом даже после четкого указания где лежит код относящийся к package ¯\_(ツ)_/¯ (то есть ExampleProject, docs и тд) - будем держать кулачки чтобы в будущих версиях поправили

**Как проверить**

Немного странный, но вариант:
- Скопировать отдельно ExampleProject - как отдельный проект (почему не сделать тут же - потому что xcode может устроить вам некоторые утехи  (＞﹏＜) )
- Отключить в нем pod с либой, запустить `pod install`, **ОБЯЗАТЕЛЬНО** почистить весь кэш проекта - и DerivedData и все все все (иначе можно ловить разные баги, если поймали - попробуйте снова очистить кэш)
- Перейти в настройки проекта, проект - swift Packages - добавить пакет 
     *адрес - `https://github.com/chausovSurfStudio/TextFieldsCatalog.git`
     *коммит - `b29bfb3cd2dc59c4ca04fed81d381599032d1e41`
- Дождаться установки пакета и InputMask
- Запустить проект



**Еще немного информации**

Данный пр был успешно проверен на проекте где используются поля через поды  (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧
Если захотите повторить - будьте готовы к доп правкам из-за новой версии `InputMask` и необходимости прописывать `import UIKit/Foundation` там где используются поля
