### PR TITLE
Switch to not existed responder

### DIFF
--- a/TextFieldsCatalog/Library/Protocols/TextField/RespondableField.swift
+++ b/TextFieldsCatalog/Library/Protocols/TextField/RespondableField.swift
@@ -30,6 +30,8 @@ public protocol RespondableField {
     var previousInput: UIResponder? { get set }
     /// Returns a Boolean value indicating whether this object is the first responder.
     var isFirstResponder: Bool { get }
+    /// Returns a Boolean value indicating whether this object can become the first responder.
+    var canBecomeFirstResponder: Bool { get }
 
     /// Asks UIKit to make this object the first responder in its window.
     func becomeFirstResponder() -> Bool

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -456,10 +456,16 @@ extension UnderlinedTextField: GuidedTextField {
     }
 
     public func switchToPreviousInput() {
+        guard previousInput?.canBecomeFirstResponder == true else {
+            return
+        }
         previousInput?.becomeFirstResponder()
     }
 
     public func switchToNextInput() {
+        guard nextInput?.canBecomeFirstResponder == true else {
+            return
+        }
         nextInput?.becomeFirstResponder()
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -202,6 +202,9 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     open override func becomeFirstResponder() -> Bool {
         return textField.becomeFirstResponder()
     }
+    open override var canBecomeFirstResponder: Bool {
+        return self.window != nil
+    }
 
     // MARK: - Public Methods
 
@@ -456,17 +459,11 @@ extension UnderlinedTextField: GuidedTextField {
     }
 
     public func switchToPreviousInput() {
-        guard previousInput?.canBecomeFirstResponder == true else {
-            return
-        }
-        previousInput?.becomeFirstResponder()
+        switchToResponder(responder: previousInput)
     }
 
     public func switchToNextInput() {
-        guard nextInput?.canBecomeFirstResponder == true else {
-            return
-        }
-        nextInput?.becomeFirstResponder()
+        switchToResponder(responder: nextInput)
     }
 
 }
@@ -608,6 +605,17 @@ private extension UnderlinedTextField {
 
     func perfromOnContainerStateChangedCall() {
         onContainerStateChanged?(containerState)
+    }
+
+    func switchToResponder(responder: UIResponder?) {
+        if let input = responder as? RespondableField {
+            guard input.canBecomeFirstResponder else {
+                return
+            }
+            _ = input.becomeFirstResponder()
+        } else {
+            previousInput?.becomeFirstResponder()
+        }
     }
 
 }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -459,11 +459,11 @@ extension UnderlinedTextField: GuidedTextField {
     }
 
     public func switchToPreviousInput() {
-        switchToResponder(responder: previousInput)
+        switchToResponder(previousInput)
     }
 
     public func switchToNextInput() {
-        switchToResponder(responder: nextInput)
+        switchToResponder(nextInput)
     }
 
 }
@@ -607,7 +607,7 @@ private extension UnderlinedTextField {
         onContainerStateChanged?(containerState)
     }
 
-    func switchToResponder(responder: UIResponder?) {
+    func switchToResponder(_ responder: UIResponder?) {
         if let input = responder as? RespondableField {
             guard input.canBecomeFirstResponder else {
                 return

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -614,7 +614,7 @@ private extension UnderlinedTextField {
             }
             _ = input.becomeFirstResponder()
         } else {
-            previousInput?.becomeFirstResponder()
+            responder?.becomeFirstResponder()
         }
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -489,7 +489,7 @@ private extension UnderlinedTextView {
             }
             _ = input.becomeFirstResponder()
         } else {
-            previousInput?.becomeFirstResponder()
+            responder?.becomeFirstResponder()
         }
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -349,11 +349,11 @@ extension UnderlinedTextView: GuidedTextField {
     }
 
     public func switchToPreviousInput() {
-        switchToResponder(responder: previousInput)
+        switchToResponder(previousInput)
     }
 
     public func switchToNextInput() {
-        switchToResponder(responder: nextInput)
+        switchToResponder(nextInput)
     }
 
 }
@@ -482,7 +482,7 @@ private extension UnderlinedTextView {
         onContainerStateChanged?(containerState)
     }
 
-    func switchToResponder(responder: UIResponder?) {
+    func switchToResponder(_ responder: UIResponder?) {
         if let input = responder as? RespondableField {
             guard input.canBecomeFirstResponder else {
                 return

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -177,6 +177,9 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     open override func becomeFirstResponder() -> Bool {
         return textView.becomeFirstResponder()
     }
+    open override var canBecomeFirstResponder: Bool {
+        return self.window != nil
+    }
 
     // MARK: - Public Methods
 
@@ -346,11 +349,11 @@ extension UnderlinedTextView: GuidedTextField {
     }
 
     public func switchToPreviousInput() {
-        previousInput?.becomeFirstResponder()
+        switchToResponder(responder: previousInput)
     }
 
     public func switchToNextInput() {
-        nextInput?.becomeFirstResponder()
+        switchToResponder(responder: nextInput)
     }
 
 }
@@ -477,6 +480,17 @@ private extension UnderlinedTextView {
 
     func perfromOnContainerStateChangedCall() {
         onContainerStateChanged?(containerState)
+    }
+
+    func switchToResponder(responder: UIResponder?) {
+        if let input = responder as? RespondableField {
+            guard input.canBecomeFirstResponder else {
+                return
+            }
+            _ = input.becomeFirstResponder()
+        } else {
+            previousInput?.becomeFirstResponder()
+        }
     }
 
 }


### PR DESCRIPTION
Рассказываю причины произошедшего.

Был баг. Заходим на экран - там куча полей (форма обратной связи). Начинаем по стрелкам в тулбаре переключаться на следующее поле, потом на следующее, и тд. До конца доходим. Затем идем в обратную сторону. Пару раз переход к предыдущему полю работает.

Но подскроллы работают таким образом, что со временем контент таблицы устаканивается так, что ячейка с активным полем ввода находится четко сверху. Пытаемся переключиться на предыдущее - и не работает. Что не удивительно, так как ячейки предыдущего поля ввода на экране нет -> система не знает что делать. Но при этом она понимает, что firstResponder-ом стало другое поле. И если смахнуть экран (форма обратной связи - смахиваемая модалка) - то клавиатура останется висеть) и переход к следующему полю ввода кажется перестанет работать, но это уже точно не помню

Вот такие пироги. Как я вижу решение:
* сначала вот эта вот фича, что в ПРе. Фактически - мы не даем переключиться на поле ввода, если оно не находится в данный момент на экране. Чтобы клавиатура не оставалась в таких кейсах висеть
* а потом уже поправить подскроллы, чтобы в целом избежать таких кейсов

На проекте протестил, вроде робит