### PR TITLE
Доработана возможность кастомизировать MaskedTextFieldDelegate и обрезать пробелы

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "TextFieldsCatalog",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v10)
     ],
     products: [
         .library(
@@ -30,21 +30,21 @@ let package = Package(
                 "Info.plist"
             ],
             resources: [
-                .process("Resources/Images/leftArrow@2x.png"),
-                .process("Resources/Images/leftArrow@3x.png"),
+                .process("Resources/Images/close.png"),
+                .process("Resources/Images/close@2x.png"),
                 .process("Resources/Images/close@3x.png"),
                 .process("Resources/Images/eyeOff.png"),
+                .process("Resources/Images/eyeOff@2x.png"),
                 .process("Resources/Images/eyeOff@3x.png"),
                 .process("Resources/Images/eyeOn.png"),
-                .process("Resources/Images/close@2x.png"),
-                .process("Resources/Images/eyeOff@2x.png"),
-                .process("Resources/Images/rightArrow@2x.png"),
-                .process("Resources/Images/rightArrow.png"),
-                .process("Resources/Images/leftArrow.png"),
-                .process("Resources/Images/rightArrow@3x.png"),
-                .process("Resources/Images/eyeOn@3x.png"),
                 .process("Resources/Images/eyeOn@2x.png"),
-                .process("Resources/Images/close.png")
+                .process("Resources/Images/eyeOn@3x.png"),
+                .process("Resources/Images/leftArrow.png"),
+                .process("Resources/Images/leftArrow@2x.png"),
+                .process("Resources/Images/leftArrow@3x.png"),
+                .process("Resources/Images/rightArrow.png"),
+                .process("Resources/Images/rightArrow@2x.png"),
+                .process("Resources/Images/rightArrow@3x.png")
             ]
         ),
         .testTarget(

--- a/TextFieldsCatalog/Library/Utils/MaskTextFieldFormatter.swift
+++ b/TextFieldsCatalog/Library/Utils/MaskTextFieldFormatter.swift
@@ -33,12 +33,12 @@ public final class MaskTextFieldFormatter: NSObject {
 
     // MARK: - Initialization
 
-    public convenience init(mask: String) {
-        self.init(mask: mask, notations: FormatterMasks.notations())
+    public convenience init(mask: String, delegate: MaskedTextFieldDelegate? = nil) {
+        self.init(mask: mask, notations: FormatterMasks.notations(), delegate: delegate)
     }
 
-    public init(mask: String, notations: [Notation]) {
-        self.maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask)
+    public init(mask: String, notations: [Notation], delegate: MaskedTextFieldDelegate? = nil) {
+        self.maskedDelegate = delegate ?? MaskedTextFieldDelegate(primaryFormat: mask)
         self.maskedDelegate.customNotations = notations
         super.init()
     }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -385,12 +385,16 @@ extension UnderlinedTextField: UITextFieldDelegate {
         onBeginEditing?(self)
     }
 
-    open func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-        validateWithPolicy()
-        state = .normal
+    open func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         if trimSpaces {
             textField.text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
         }
+        return true
+    }
+
+    open func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
+        validateWithPolicy()
+        state = .normal
         onEndEditing?(self)
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -107,6 +107,7 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     public var hideOnReturn: Bool = true
     public var validateWithFormatter: Bool = false
     public var validationPolicy: ValidationPolicy = .always
+    public var trimSpaces: Bool = false
     public var heightLayoutPolicy: HeightLayoutPolicy = .elastic(minHeight: 77, bottomSpace: 5, ignoreEmptyHint: false) {
         didSet {
             hintService?.setup(heightLayoutPolicy: heightLayoutPolicy)
@@ -387,6 +388,9 @@ extension UnderlinedTextField: UITextFieldDelegate {
     open func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
         validateWithPolicy()
         state = .normal
+        if trimSpaces {
+            textField.text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         onEndEditing?(self)
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -98,6 +98,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     public var maxLength: Int?
     public var hideClearButton = false
     public var validationPolicy: ValidationPolicy = .always
+    public var trimSpaces: Bool = false
     public var flexibleHeightPolicy = FlexibleHeightPolicy(minHeight: 77,
                                                            bottomOffset: 5,
                                                            ignoreEmptyHint: true)
@@ -367,6 +368,9 @@ extension UnderlinedTextView: UITextViewDelegate {
     open func textViewDidEndEditing(_ textView: UITextView) {
         validateWithPolicy()
         state = .normal
+        if trimSpaces {
+            textView.text = textView.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         onEndEditing?(self)
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -365,12 +365,16 @@ extension UnderlinedTextView: UITextViewDelegate {
         onBeginEditing?(self)
     }
 
-    open func textViewDidEndEditing(_ textView: UITextView) {
-        validateWithPolicy()
-        state = .normal
+    open func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         if trimSpaces {
             textView.text = textView.text?.trimmingCharacters(in: .whitespacesAndNewlines)
         }
+        return true
+    }
+
+    open func textViewDidEndEditing(_ textView: UITextView) {
+        validateWithPolicy()
+        state = .normal
         onEndEditing?(self)
     }
 


### PR DESCRIPTION
После #99

**Что сделано** 

- `MaskedTextFieldDelegate` можно передавать свой, или не передавать и будет работать созданный по умолчанию - кастомизация MaskedTextFieldDelegate позволит редактировать вставляемый текст в поле с `maskFormatter` != nil - так как он (`maskFormatter`) перехватывает и первым обрабатывает ввод в поле
- Для `textField` и `textView` добавлен параметр `trimSpaces` - после того как поле становится неактивным - обрезает пробелы и переходы на новую строку (по умолчанию false) 

**Подумать**

- Была идея запрещать ввод пробелов, но мы можем это сделать установив `customNotation` для `maskFormatter` - стоит ли создавать ее по умолчанию - если нам может понадобится ограничивать ввод чем то дополнительным - или же идея что у нас по мере ввода будут проверяться еще и пробелы допом? (но вообще в целом кажется избыточным если делается все недолго)
- Выпиливание emoji - для `Unicode.Scalar `есть параметр `isEmoji`, но доступно оно только с ios 10.2 - будем поднимать? если да - то так же можно добавить параметр `clearEmojis` например и так же как с пробелами доработать

**Как проверить**

Самый быстрый способ - прописать по умолчанию `trimSpaces = true` и запустить приложение примеров