### PR TITLE
Abstract hint service

### DIFF
--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
@@ -92,7 +92,9 @@ private extension BoxTextField {
                                                                                             normal: Color.UnderlineTextField.placeholder,
                                                                                             active: Color.UnderlineTextField.placeholder,
                                                                                             disabled: Color.UnderlineTextField.placeholder))))
-        self.heightLayoutPolicy = .elastic(minHeight: 130, bottomSpace: 5, ignoreEmptyHint: false)
+        self.heightLayoutPolicy = .elastic(policy: .init(minHeight: 130,
+                                                         bottomOffset: 5,
+                                                         ignoreEmptyHint: false))
         self.validationPolicy = .always
     }
 

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
@@ -91,7 +91,8 @@ private extension BoxTextField {
                                                                  colors: ColorConfiguration(error: Color.UnderlineTextField.error,
                                                                                             normal: Color.UnderlineTextField.placeholder,
                                                                                             active: Color.UnderlineTextField.placeholder,
-                                                                                            disabled: Color.UnderlineTextField.placeholder))))
+                                                                                            disabled: Color.UnderlineTextField.placeholder)),
+                                            visibleHintStates: .all))
         self.heightLayoutPolicy = .elastic(policy: .init(minHeight: 130,
                                                          bottomOffset: 5,
                                                          ignoreEmptyHint: false))

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
@@ -74,12 +74,6 @@ private extension BoxTextField {
                                                                                     normal: Color.UnderlineTextField.text,
                                                                                     active: Color.UnderlineTextField.text,
                                                                                     disabled: Color.UnderlineTextField.placeholder))
-        configuration.hint = HintConfiguration(font: UIFont.systemFont(ofSize: 13, weight: .regular),
-                                               lineHeight: 17,
-                                               colors: ColorConfiguration(error: Color.UnderlineTextField.error,
-                                                                          normal: Color.UnderlineTextField.placeholder,
-                                                                          active: Color.UnderlineTextField.placeholder,
-                                                                          disabled: Color.UnderlineTextField.placeholder))
         configuration.passwordMode = PasswordModeConfiguration(secureModeOnImage: UIImage(asset: Asset.customEyeOn),
                                                                secureModeOffImage: UIImage(asset: Asset.customEyeOff),
                                                                normalColor: Color.UnderlineTextField.ActionButton.normal,
@@ -92,6 +86,12 @@ private extension BoxTextField {
                                                                insets: UIEdgeInsets(top: 13, left: 16, bottom: 0, right: 16),
                                                                colors: ColorConfiguration(color: Color.UnderlineTextField.placeholder))
         self.setup(placeholderServices: [StaticPlaceholderService(configuration: placeholderConfig)])
+        self.setup(hintService: HintService(configuration: .init(font: UIFont.systemFont(ofSize: 13, weight: .regular),
+                                                                 lineHeight: 17,
+                                                                 colors: ColorConfiguration(error: Color.UnderlineTextField.error,
+                                                                                            normal: Color.UnderlineTextField.placeholder,
+                                                                                            active: Color.UnderlineTextField.placeholder,
+                                                                                            disabled: Color.UnderlineTextField.placeholder))))
         self.heightLayoutPolicy = .elastic(minHeight: 130, bottomSpace: 5, ignoreEmptyHint: false)
         self.validationPolicy = .always
     }

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/SumTextField/SumTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/SumTextField/SumTextField.swift
@@ -103,12 +103,6 @@ private extension SumTextField {
                                                                                     normal: Color.UnderlineTextField.text,
                                                                                     active: Color.UnderlineTextField.text,
                                                                                     disabled: Color.UnderlineTextField.placeholder))
-        configuration.hint = HintConfiguration(font: UIFont.systemFont(ofSize: 13, weight: .regular),
-                                               lineHeight: 17,
-                                               colors: ColorConfiguration(error: Color.UnderlineTextField.error,
-                                                                          normal: Color.UnderlineTextField.placeholder,
-                                                                          active: Color.UnderlineTextField.placeholder,
-                                                                          disabled: Color.UnderlineTextField.placeholder))
         configuration.background = BackgroundConfiguration(color: Color.Main.background)
         self.configuration = configuration
 
@@ -127,7 +121,12 @@ private extension SumTextField {
         self.supportPlaceholderService = supportPlaceholderService
         self.setup(placeholderServices: [StaticPlaceholderService(configuration: staticPlaceholderConfig),
                                          supportPlaceholderService])
-
+        self.setup(hintService: HintService(configuration: .init(font: UIFont.systemFont(ofSize: 13, weight: .regular),
+                                                                 lineHeight: 17,
+                                                                 colors: ColorConfiguration(error: Color.UnderlineTextField.error,
+                                                                                            normal: Color.UnderlineTextField.placeholder,
+                                                                                            active: Color.UnderlineTextField.placeholder,
+                                                                                            disabled: Color.UnderlineTextField.placeholder))))
         self.heightLayoutPolicy = .elastic(minHeight: 102, bottomSpace: 5, ignoreEmptyHint: true)
         self.validationPolicy = .afterChanges
     }

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/SumTextField/SumTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/SumTextField/SumTextField.swift
@@ -127,7 +127,9 @@ private extension SumTextField {
                                                                                             normal: Color.UnderlineTextField.placeholder,
                                                                                             active: Color.UnderlineTextField.placeholder,
                                                                                             disabled: Color.UnderlineTextField.placeholder))))
-        self.heightLayoutPolicy = .elastic(minHeight: 102, bottomSpace: 5, ignoreEmptyHint: true)
+        self.heightLayoutPolicy = .elastic(policy: .init(minHeight: 102,
+                                                         bottomOffset: 5,
+                                                         ignoreEmptyHint: true))
         self.validationPolicy = .afterChanges
     }
 

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
@@ -133,6 +133,7 @@ private extension UnderlinedFieldPreset {
         textField.field.autocapitalizationType = .words
         textField.maxLength = 20
         textField.setup(hint: L10n.Presets.Name.hint)
+        textField.setup(visibleHintStates: [.normal, .active, .error])
 
         textField.maskFormatter = MaskTextFieldFormatter(mask: FormatterMasks.name, notations: FormatterMasks.customNotations())
 

--- a/TextFieldsCatalog.xcodeproj/project.pbxproj
+++ b/TextFieldsCatalog.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		9040B90923C637A200998989 /* FlexibleHeightPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9040B90823C637A200998989 /* FlexibleHeightPolicy.swift */; };
 		90793BA025A4B90200BC8582 /* AbstractHintService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90793B9F25A4B90200BC8582 /* AbstractHintService.swift */; };
 		90793BA825A4BAB000BC8582 /* HintService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90793BA725A4BAB000BC8582 /* HintService.swift */; };
+		90793C0025A4D47600BC8582 /* HintVisibleStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90793BFF25A4D47600BC8582 /* HintVisibleStates.swift */; };
 		9082577523C367B5000767EB /* FieldContainerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9082577423C367B5000767EB /* FieldContainerState.swift */; };
 		909CE8E8235350FF001E3B7F /* ValidationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909CE8E623534E50001E3B7F /* ValidationPolicy.swift */; };
 		909DB887220355F000F0C5B7 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909DB886220355F000F0C5B7 /* String.swift */; };
@@ -137,6 +138,7 @@
 		9040B90823C637A200998989 /* FlexibleHeightPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleHeightPolicy.swift; sourceTree = "<group>"; };
 		90793B9F25A4B90200BC8582 /* AbstractHintService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractHintService.swift; sourceTree = "<group>"; };
 		90793BA725A4BAB000BC8582 /* HintService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintService.swift; sourceTree = "<group>"; };
+		90793BFF25A4D47600BC8582 /* HintVisibleStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintVisibleStates.swift; sourceTree = "<group>"; };
 		9082577423C367B5000767EB /* FieldContainerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldContainerState.swift; sourceTree = "<group>"; };
 		909CE8E623534E50001E3B7F /* ValidationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationPolicy.swift; sourceTree = "<group>"; };
 		909DB886220355F000F0C5B7 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 				9040B90323C636F600998989 /* Internal */,
 				9082577423C367B5000767EB /* FieldContainerState.swift */,
 				90AE548F220582C50054E875 /* HeightLayoutPolicy.swift */,
+				90793BFF25A4D47600BC8582 /* HintVisibleStates.swift */,
 				90F487082458329800931146 /* NativePlaceholderBehavior.swift */,
 				902CE2EE21FF702F00AC21D4 /* SharedRegex.swift */,
 				90E13DB02320FD3C004995E4 /* TextFieldMode.swift */,
@@ -820,6 +823,7 @@
 			files = (
 				90C6AC7023C617A400D13B8D /* LineService.swift in Sources */,
 				902CE2FA21FF710400AC21D4 /* TextFieldConfigurations.swift in Sources */,
+				90793C0025A4D47600BC8582 /* HintVisibleStates.swift in Sources */,
 				90F4870724582BBA00931146 /* NativePlaceholderService.swift in Sources */,
 				90A066902530B59D0065CCD7 /* ToolBarInterface.swift in Sources */,
 				90BEBBFD23C4D3FB00991105 /* InputFieldProtocol.swift in Sources */,

--- a/TextFieldsCatalog.xcodeproj/project.pbxproj
+++ b/TextFieldsCatalog.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		9040B90523C6371000998989 /* TextFieldPasswordModeBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9040B90423C6371000998989 /* TextFieldPasswordModeBehavior.swift */; };
 		9040B90723C6374400998989 /* AnimationTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9040B90623C6374400998989 /* AnimationTime.swift */; };
 		9040B90923C637A200998989 /* FlexibleHeightPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9040B90823C637A200998989 /* FlexibleHeightPolicy.swift */; };
+		90793BA025A4B90200BC8582 /* AbstractHintService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90793B9F25A4B90200BC8582 /* AbstractHintService.swift */; };
+		90793BA825A4BAB000BC8582 /* HintService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90793BA725A4BAB000BC8582 /* HintService.swift */; };
 		9082577523C367B5000767EB /* FieldContainerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9082577423C367B5000767EB /* FieldContainerState.swift */; };
 		909CE8E8235350FF001E3B7F /* ValidationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909CE8E623534E50001E3B7F /* ValidationPolicy.swift */; };
 		909DB887220355F000F0C5B7 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909DB886220355F000F0C5B7 /* String.swift */; };
@@ -69,7 +71,6 @@
 		90C0992623C8EF8000312628 /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C0992523C8EF8000312628 /* UITextField.swift */; };
 		90C0992823C8F2FF00312628 /* UITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C0992723C8F2FF00312628 /* UITextView.swift */; };
 		90C6AC7023C617A400D13B8D /* LineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6AC6F23C617A400D13B8D /* LineService.swift */; };
-		90C6AC7223C6201000D13B8D /* HintService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6AC7123C6201000D13B8D /* HintService.swift */; };
 		90C6C57223C8E360008DFBED /* FieldService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6C57123C8E360008DFBED /* FieldService.swift */; };
 		90D18FCC2452EAD80072BD2C /* AssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D18FCB2452EAD80072BD2C /* AssetManager.swift */; };
 		90D18FCE2452ED1D0072BD2C /* MaskTextFieldFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D18FCD2452ED1D0072BD2C /* MaskTextFieldFormatter.swift */; };
@@ -134,6 +135,8 @@
 		9040B90423C6371000998989 /* TextFieldPasswordModeBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldPasswordModeBehavior.swift; sourceTree = "<group>"; };
 		9040B90623C6374400998989 /* AnimationTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTime.swift; sourceTree = "<group>"; };
 		9040B90823C637A200998989 /* FlexibleHeightPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleHeightPolicy.swift; sourceTree = "<group>"; };
+		90793B9F25A4B90200BC8582 /* AbstractHintService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractHintService.swift; sourceTree = "<group>"; };
+		90793BA725A4BAB000BC8582 /* HintService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintService.swift; sourceTree = "<group>"; };
 		9082577423C367B5000767EB /* FieldContainerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldContainerState.swift; sourceTree = "<group>"; };
 		909CE8E623534E50001E3B7F /* ValidationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationPolicy.swift; sourceTree = "<group>"; };
 		909DB886220355F000F0C5B7 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -169,7 +172,6 @@
 		90C0992523C8EF8000312628 /* UITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
 		90C0992723C8F2FF00312628 /* UITextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextView.swift; sourceTree = "<group>"; };
 		90C6AC6F23C617A400D13B8D /* LineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineService.swift; sourceTree = "<group>"; };
-		90C6AC7123C6201000D13B8D /* HintService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintService.swift; sourceTree = "<group>"; };
 		90C6C57123C8E360008DFBED /* FieldService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldService.swift; sourceTree = "<group>"; };
 		90D18FCB2452EAD80072BD2C /* AssetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetManager.swift; sourceTree = "<group>"; };
 		90D18FCD2452ED1D0072BD2C /* MaskTextFieldFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskTextFieldFormatter.swift; sourceTree = "<group>"; };
@@ -467,7 +469,7 @@
 			children = (
 				90EE54BA24572DF10099C048 /* Placeholder */,
 				90C6C57123C8E360008DFBED /* FieldService.swift */,
-				90C6AC7123C6201000D13B8D /* HintService.swift */,
+				90793BA725A4BAB000BC8582 /* HintService.swift */,
 				90C6AC6F23C617A400D13B8D /* LineService.swift */,
 			);
 			path = AppearanceServices;
@@ -486,6 +488,7 @@
 			isa = PBXGroup;
 			children = (
 				90BEBBFC23C4D3FB00991105 /* InputFieldProtocol.swift */,
+				90793B9F25A4B90200BC8582 /* AbstractHintService.swift */,
 				90EE54B6245724E60099C048 /* AbstractPlaceholderService.swift */,
 			);
 			path = Support;
@@ -839,6 +842,7 @@
 				9038640C21FF5A0100BAA761 /* ResetableField.swift in Sources */,
 				90BEBBF923C4D26E00991105 /* FloatingPlaceholderService.swift in Sources */,
 				90F487092458329800931146 /* NativePlaceholderBehavior.swift in Sources */,
+				90793BA825A4BAB000BC8582 /* HintService.swift in Sources */,
 				9038640821FF59BC00BAA761 /* InnerTextField.swift in Sources */,
 				90A32B7D228975730036C634 /* PlainPickerView.swift in Sources */,
 				90E13DAF2320FCAA004995E4 /* FieldState.swift in Sources */,
@@ -863,7 +867,7 @@
 				909CE8E8235350FF001E3B7F /* ValidationPolicy.swift in Sources */,
 				90A5D38D228E9AEF000322A2 /* AccessibilityIdentifiers.swift in Sources */,
 				902CE2F121FF707E00AC21D4 /* FormatterMasks.swift in Sources */,
-				90C6AC7223C6201000D13B8D /* HintService.swift in Sources */,
+				90793BA025A4B90200BC8582 /* AbstractHintService.swift in Sources */,
 				9038640A21FF59D300BAA761 /* Foundation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TextFieldsCatalog/Resources/Constants/HeightLayoutPolicy.swift
+++ b/TextFieldsCatalog/Resources/Constants/HeightLayoutPolicy.swift
@@ -11,18 +11,9 @@ import UIKit
 public enum HeightLayoutPolicy {
     /// Fixed height of text field
     case fixed
-    /// Flexible height of text field.
-    /// Also allows you to configure minimal height for text field and bottom space value under hint label.
-    /// The resulting height is obtained as sum of y-coordinate of the hint label, it's height and bottomSpace value.
-    @available(*, deprecated, message: "Use `elastic(_,_,_)` instead with ignoreEmptyHint == false for backward capability. It's case will be removed later")
-    case flexible(CGFloat, CGFloat)
     /**
-     Flexible height of text field.
+     Flexible height policy for text field.
      Also allows you to configure minimal height for text field and bottom space value under hint label.
-
-     Final height depends on `ignoreEmptyHint` value:
-     - if `ignoreEmptyHint` == true, then if you hint is empty - then algoritm will use `minHeight` as view height
-     - if `ignoreEmptyHint` == false, then resulting height is obtained always as sum of y-coordinate of the hint label, it's height and bottomSpace value
      */
-    case elastic(minHeight: CGFloat, bottomSpace: CGFloat, ignoreEmptyHint: Bool)
+    case elastic(policy: FlexibleHeightPolicy)
 }

--- a/TextFieldsCatalog/Resources/Constants/HintVisibleStates.swift
+++ b/TextFieldsCatalog/Resources/Constants/HintVisibleStates.swift
@@ -6,6 +6,11 @@
 //  Copyright © 2021 Александр Чаусов. All rights reserved.
 //
 
+/// Option set for managing possible visible states for fields hint message.
+///
+/// You can provide needed set to hint service init method or
+/// change this set for specific field with appropriate method.
+/// Hint or error messages will be shown only for specified states.
 public struct HintVisibleStates: OptionSet {
 
     // MARK: - Public Properties

--- a/TextFieldsCatalog/Resources/Constants/HintVisibleStates.swift
+++ b/TextFieldsCatalog/Resources/Constants/HintVisibleStates.swift
@@ -1,0 +1,28 @@
+//
+//  HintMessageState.swift
+//  TextFieldsCatalog
+//
+//  Created by Александр Чаусов on 05.01.2021.
+//  Copyright © 2021 Александр Чаусов. All rights reserved.
+//
+
+public struct HintVisibleStates: OptionSet {
+
+    // MARK: - Public Properties
+
+    public let rawValue: Int
+
+    public static let error = HintVisibleStates(rawValue: 1 << 0)
+    public static let disabled = HintVisibleStates(rawValue: 1 << 1)
+    public static let normal = HintVisibleStates(rawValue: 1 << 2)
+    public static let active = HintVisibleStates(rawValue: 1 << 3)
+
+    public static let all: HintVisibleStates = [.error, .disabled, .normal, .active]
+
+    // MARK: - Initialization
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+}

--- a/TextFieldsCatalog/TextFields/Configuration/FlexibleHeightPolicy.swift
+++ b/TextFieldsCatalog/TextFields/Configuration/FlexibleHeightPolicy.swift
@@ -8,12 +8,16 @@
 
 import UIKit
 
+/**
+ Flexible height policy for text field/view.
+ Also allows you to configure minimal height for input field and bottom space value under hint label.
+ */
 public struct FlexibleHeightPolicy {
 
     // MARK: - Properties
 
     let minHeight: CGFloat
-    /// additional offset (usually used for offset between hintLabel and textView)
+    /// additional offset (usually used for offset between hintLabel and textField/textView)
     let bottomOffset: CGFloat
     /**
     Final height depends on `ignoreEmptyHint` value:
@@ -26,7 +30,7 @@ public struct FlexibleHeightPolicy {
 
     public init(minHeight: CGFloat,
                 bottomOffset: CGFloat,
-                ignoreEmptyHint: Bool = false) {
+                ignoreEmptyHint: Bool) {
         self.minHeight = minHeight
         self.bottomOffset = bottomOffset
         self.ignoreEmptyHint = ignoreEmptyHint

--- a/TextFieldsCatalog/TextFields/Configuration/TextFieldConfigurations.swift
+++ b/TextFieldsCatalog/TextFields/Configuration/TextFieldConfigurations.swift
@@ -14,18 +14,15 @@ public class BaseFieldConfiguration {
 
     public var textField: TextFieldConfiguration
     public var line: LineConfiguration
-    public var hint: HintConfiguration
     public var background: BackgroundConfiguration
 
     // MARK: - Initialization
 
     init(textField: TextFieldConfiguration,
          line: LineConfiguration,
-         hint: HintConfiguration,
          background: BackgroundConfiguration) {
         self.textField = textField
         self.line = line
-        self.hint = hint
         self.background = background
     }
 
@@ -57,12 +54,6 @@ public final class UnderlinedTextFieldConfiguration: BaseFieldConfiguration {
                                                                           normal: Color.Text.white,
                                                                           active: Color.Text.white,
                                                                           disabled: Color.Text.gray))
-        let hint = HintConfiguration(font: UIFont.systemFont(ofSize: 12, weight: .regular),
-                                     lineHeight: 16,
-                                     colors: ColorConfiguration(error: Color.Main.red,
-                                                                normal: Color.Text.gray,
-                                                                active: Color.Text.gray,
-                                                                disabled: Color.Text.gray))
         let background = BackgroundConfiguration(color: Color.Main.background)
 
         passwordMode = PasswordModeConfiguration(secureModeOnImage: AssetManager().getImage("eyeOn"),
@@ -71,7 +62,6 @@ public final class UnderlinedTextFieldConfiguration: BaseFieldConfiguration {
                                                  pressedColor: Color.Button.pressed)
         super.init(textField: textField,
                    line: line,
-                   hint: hint,
                    background: background)
     }
 
@@ -103,12 +93,6 @@ public final class UnderlinedTextViewConfiguration: BaseFieldConfiguration {
                                                                           normal: Color.Text.white,
                                                                           active: Color.Text.white,
                                                                           disabled: Color.Text.gray))
-        let hint = HintConfiguration(font: UIFont.systemFont(ofSize: 12, weight: .regular),
-                                     lineHeight: 16,
-                                     colors: ColorConfiguration(error: Color.Main.red,
-                                                                normal: Color.Text.gray,
-                                                                active: Color.Text.gray,
-                                                                disabled: Color.Text.gray))
         let background = BackgroundConfiguration(color: Color.Main.background)
 
         clearButton = ActionButtonConfiguration(image: AssetManager().getImage("close"),
@@ -116,7 +100,6 @@ public final class UnderlinedTextViewConfiguration: BaseFieldConfiguration {
                                                 pressedColor: Color.Button.pressed)
         super.init(textField: textField,
                    line: line,
-                   hint: hint,
                    background: background)
     }
 
@@ -148,6 +131,19 @@ extension FloatingPlaceholderConfiguration {
                                                                                  normal: Color.Text.white,
                                                                                  active: Color.Text.active,
                                                                                  disabled: Color.Text.gray))
+    }
+
+}
+
+extension HintConfiguration {
+
+    static var `default`: HintConfiguration {
+        return HintConfiguration(font: UIFont.systemFont(ofSize: 12, weight: .regular),
+                                 lineHeight: 16,
+                                 colors: ColorConfiguration(error: Color.Main.red,
+                                                            normal: Color.Text.gray,
+                                                            active: Color.Text.gray,
+                                                            disabled: Color.Text.gray))
     }
 
 }

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2021 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 public class HintService: AbstractHintService {
 
     // MARK: - Private Properties

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+/// Default service for hint messages presentation in textField/textView.
+/// You can find documentation for it's methods in `AbstractHintService` protocol documentation.
 public class HintService: AbstractHintService {
 
     // MARK: - Private Properties

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
@@ -13,13 +13,16 @@ public class HintService: AbstractHintService {
     // MARK: - Private Properties
 
     private let configuration: HintConfiguration
+    private var visibleHintStates: HintVisibleStates
     private var hintLabel: UILabel?
     private var hintMessage: String?
 
     // MARK: - Initialization
 
-    public init(configuration: HintConfiguration) {
+    public init(configuration: HintConfiguration,
+                visibleHintStates: HintVisibleStates = [.error, .active]) {
         self.configuration = configuration
+        self.visibleHintStates = visibleHintStates
     }
 
     // MARK: - AbstractHintService
@@ -73,6 +76,10 @@ public class HintService: AbstractHintService {
         setup(hintText: hintMessage)
     }
 
+    public func setup(visibleHintStates: HintVisibleStates) {
+        self.visibleHintStates = visibleHintStates
+    }
+
 }
 
 // MARK: - Private Updates
@@ -119,13 +126,18 @@ private extension HintService {
     }
 
     func shouldShowHint(containerState: FieldContainerState) -> Bool {
+        guard !(hintLabel?.text?.isEmpty ?? true) else {
+            return false
+        }
         switch containerState {
         case .error:
-            return true
-        case .disabled, .normal:
-            return false
+            return visibleHintStates.contains(.error)
+        case .disabled:
+            return visibleHintStates.contains(.disabled)
+        case .normal:
+            return visibleHintStates.contains(.normal)
         case .active:
-            return hintMessage != nil
+            return visibleHintStates.contains(.active)
         }
     }
 

--- a/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/AppearanceServices/HintService.swift
@@ -92,7 +92,7 @@ private extension HintService {
         case .fixed:
             // update always with animation
             break
-        case .flexible, .elastic:
+        case .elastic:
             // update with animation on hint appear
             duration = hintIsVisible ? AnimationTime.default : 0
         }

--- a/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
@@ -18,5 +18,6 @@ public protocol AbstractHintService {
     func setup(plainHint: String?)
     func setup(errorHint: String?)
     func showHint()
+    func setup(visibleHintStates: HintVisibleStates)
 
 }

--- a/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
@@ -8,16 +8,49 @@
 
 import UIKit
 
-public protocol AbstractHintService {
+/**
+ Abstract protocl for hint service.
 
+ You can use existed `HintService` from this library, this service will do all work for supporting hint messages,
+ or you can provide your own service which have to implement this protocol.
+ */
+public protocol AbstractHintService {
+    /**
+     This method provides your service with a label, where you have to place hint message
+     */
     func provide(label: UILabel)
+    /**
+     Method where you have to setup initial state for hint label
+     */
     func configureAppearance()
+    /**
+     Method invokes when field wants to update UI elements.
+     You have to update visibility of you hint, it's color, etc.
+     */
     func updateContent(containerState: FieldContainerState, heightLayoutPolicy: HeightLayoutPolicy)
+    /**
+     Method allows to calculate current hint message height,
+     or returns zero if hint message doesn't exist or invisible
+     */
     func hintHeight(containerState: FieldContainerState) -> CGFloat
 
+    /**
+     Method allows setup hint message
+     */
     func setup(plainHint: String?)
+    /**
+     Method allows setup error hint message.
+
+     If errorHint is nil - you have to save previous plain hint message in label, if it exists.
+     */
     func setup(errorHint: String?)
+    /**
+     Method to drop all error hint messages and present plain hint, if it exists.
+     */
     func showHint()
+    /**
+     Service method, which allows you to change current visible hint states.
+     */
     func setup(visibleHintStates: HintVisibleStates)
 
 }

--- a/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2021 Александр Чаусов. All rights reserved.
 //
 
+import UIKit
+
 public protocol AbstractHintService {
 
     func provide(label: UILabel)

--- a/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
+++ b/TextFieldsCatalog/TextFields/Services/Support/AbstractHintService.swift
@@ -1,0 +1,20 @@
+//
+//  AbstractHintService.swift
+//  TextFieldsCatalog
+//
+//  Created by Александр Чаусов on 05.01.2021.
+//  Copyright © 2021 Александр Чаусов. All rights reserved.
+//
+
+public protocol AbstractHintService {
+
+    func provide(label: UILabel)
+    func configureAppearance()
+    func updateContent(containerState: FieldContainerState, heightLayoutPolicy: HeightLayoutPolicy)
+    func hintHeight(containerState: FieldContainerState) -> CGFloat
+
+    func setup(plainHint: String?)
+    func setup(errorHint: String?)
+    func showHint()
+
+}

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -240,6 +240,13 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
         hintService.setup(plainHint: hint)
     }
 
+    /// Allows you to refresh set of states, when hint message or error message
+    /// should be visible
+    public func setup(visibleHintStates: HintVisibleStates) {
+        self.hintService.setup(visibleHintStates: visibleHintStates)
+        updateUI()
+    }
+
     /// Allows you to set optional string as text.
     /// - Parameters:
     ///     - text: text for setup

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -219,6 +219,15 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
         placeholderServices.append(service)
     }
 
+    /// Allows you to change default hint service
+    public func setup(hintService: AbstractHintService) {
+        self.hintService = hintService
+        hintService.provide(label: hintLabel)
+        hintService.configureAppearance()
+        hintService.updateContent(containerState: containerState,
+                                  heightLayoutPolicy: heightLayoutPolicy)
+    }
+
     /// Allows you to set constraint on view height, this constraint will be changed if view height is changed later
     public func setup(heightConstraint: NSLayoutConstraint) {
         self.heightConstraint = heightConstraint

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -108,7 +108,9 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     public var validateWithFormatter: Bool = false
     public var validationPolicy: ValidationPolicy = .always
     public var trimSpaces: Bool = false
-    public var heightLayoutPolicy: HeightLayoutPolicy = .elastic(minHeight: 77, bottomSpace: 5, ignoreEmptyHint: false)
+    public var heightLayoutPolicy: HeightLayoutPolicy = .elastic(policy: .init(minHeight: 77,
+                                                                               bottomOffset: 5,
+                                                                               ignoreEmptyHint: false))
     public var mode: TextFieldMode = .plain {
         didSet {
             setup(textFieldMode: mode)
@@ -627,24 +629,14 @@ private extension UnderlinedTextField {
         switch heightLayoutPolicy {
         case .fixed:
             break
-        case .flexible(let minHeight, let bottomSpace):
-            let hintHeight: CGFloat = hintService.hintHeight(containerState: containerState)
-            let actualViewHeight = hintLabel.frame.origin.y + hintHeight + bottomSpace
-            let viewHeight = max(minHeight, actualViewHeight)
-            guard lastViewHeight != viewHeight else {
-                return
-            }
-            lastViewHeight = viewHeight
-            heightConstraint?.constant = viewHeight
-            onHeightChanged?(viewHeight)
-        case .elastic(let minHeight, let bottomSpace, let ignoreEmptyHint):
+        case .elastic(let policy):
             let viewHeight: CGFloat
             let hintHeight: CGFloat = hintService.hintHeight(containerState: containerState)
-            if hintHeight != 0 || !ignoreEmptyHint {
-                let actualViewHeight = hintLabel.frame.origin.y + hintHeight + bottomSpace
-                viewHeight = max(minHeight, actualViewHeight)
+            if hintHeight != 0 || !policy.ignoreEmptyHint {
+                let actualViewHeight = hintLabel.frame.origin.y + hintHeight + policy.bottomOffset
+                viewHeight = max(policy.minHeight, actualViewHeight)
             } else {
-                viewHeight = minHeight
+                viewHeight = policy.minHeight
             }
 
             guard lastViewHeight != viewHeight else {

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -204,6 +204,17 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
         placeholderServices.append(service)
     }
 
+    /// Allows you to change default hint service
+    public func setup(hintService: AbstractHintService) {
+        self.hintService = hintService
+        hintService.provide(label: hintLabel)
+        hintService.configureAppearance()
+        hintService.updateContent(containerState: containerState,
+                                  heightLayoutPolicy: .elastic(minHeight: flexibleHeightPolicy.minHeight,
+                                                               bottomSpace: flexibleHeightPolicy.bottomOffset,
+                                                               ignoreEmptyHint: flexibleHeightPolicy.ignoreEmptyHint))
+    }
+
     /// Allows you to set constraint on view height, this constraint will be changed if view height is changed later
     public func setup(heightConstraint: NSLayoutConstraint) {
         self.heightConstraint = heightConstraint

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -53,7 +53,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     // MARK: - Services
 
     private var fieldService: FieldService?
-    private var hintService: HintService?
+    private var hintService: AbstractHintService = HintService(configuration: .default)
     private var lineService: LineService?
     private var placeholderServices: [AbstractPlaceholderService] = [FloatingPlaceholderService(configuration: .defaultForTextView)]
 
@@ -211,11 +211,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
 
     /// Allows you to set some string as hint message
     public func setup(hint: String) {
-        guard !hint.isEmpty else {
-            return
-        }
-        hintService?.setup(hintMessage: hint)
-        hintService?.setupHintText(hint)
+        hintService.setup(plainHint: hint)
     }
 
     /// Allows you to set optional string as text.
@@ -238,9 +234,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     /// Allows to set view in 'error' state, optionally allows you to set the error message. If errorMessage is nil - label keeps the previous info message
     public func setError(with errorMessage: String?, animated: Bool) {
         error = true
-        if let message = errorMessage {
-            hintService?.setupHintText(message)
-        }
+        hintService.setup(errorHint: errorMessage)
         updateUI()
     }
 
@@ -258,7 +252,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     /// Clear text, reset error and update all UI elements - reset to default state
     public func reset() {
         textView.text = ""
-        hintService?.setupHintIfNeeded()
+        hintService.showHint()
         error = false
         updateUI()
         updateClearButtonVisibility()
@@ -280,9 +274,6 @@ private extension UnderlinedTextView {
         fieldService = FieldService(field: textView,
                                     configuration: configuration.textField,
                                     backgroundConfiguration: configuration.background)
-        hintService = HintService(hintLabel: hintLabel,
-                                  configuration: configuration.hint,
-                                  heightLayoutPolicy: .elastic(minHeight: 0, bottomSpace: 0, ignoreEmptyHint: false))
         lineService = LineService(superview: self,
                                   field: textView,
                                   configuration: configuration.line)
@@ -291,16 +282,16 @@ private extension UnderlinedTextView {
     func configureAppearance() {
         fieldService?.setup(configuration: configuration.textField,
                             backgroundConfiguration: configuration.background)
-        hintService?.setup(configuration: configuration.hint)
         lineService?.setup(configuration: configuration.line)
+        hintService.provide(label: hintLabel)
         for service in placeholderServices {
             service.provide(superview: self.view, field: textView)
         }
 
         fieldService?.configureBackground()
         fieldService?.configure(textView: textView)
-        hintService?.configureHintLabel()
         lineService?.configureLineView(fieldState: state)
+        hintService.configureAppearance()
         for service in placeholderServices {
             service.configurePlaceholder(fieldState: state,
                                          containerState: containerState)
@@ -410,7 +401,10 @@ private extension UnderlinedTextView {
 
     func updateUI(animated: Bool = false) {
         fieldService?.updateContent(containerState: containerState)
-        hintService?.updateContent(containerState: containerState)
+        hintService.updateContent(containerState: containerState,
+                                  heightLayoutPolicy: .elastic(minHeight: flexibleHeightPolicy.minHeight,
+                                                               bottomSpace: flexibleHeightPolicy.bottomOffset,
+                                                               ignoreEmptyHint: flexibleHeightPolicy.ignoreEmptyHint))
         for service in placeholderServices {
             service.updateContent(fieldState: state, containerState: containerState)
         }
@@ -444,7 +438,7 @@ private extension UnderlinedTextView {
             let (isValid, errorMessage) = currentValidator.validate(textView.text)
             error = !isValid
             if let message = errorMessage, !isValid {
-                hintService?.setupHintText(message)
+                hintService.setup(errorHint: message)
             }
         }
         if error {
@@ -454,7 +448,7 @@ private extension UnderlinedTextView {
 
     func removeError() {
         if error {
-            hintService?.setupHintIfNeeded()
+            hintService.showHint()
             error = false
             updateUI()
         } else {
@@ -508,7 +502,7 @@ private extension UnderlinedTextView {
 private extension UnderlinedTextView {
 
     func updateViewHeight() {
-        let hintHeight = hintService?.hintLabelHeight(containerState: containerState) ?? 0
+        let hintHeight = hintService.hintHeight(containerState: containerState)
         let textHeight = min(textViewHeight(), maxTextContainerHeight ?? CGFloat.greatestFiniteMagnitude)
         let freeSpace = freeVerticalSpace(isEmptyHint: hintHeight == 0)
         let actualViewHeight = textHeight + hintHeight + freeSpace

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -223,6 +223,13 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
         hintService.setup(plainHint: hint)
     }
 
+    /// Allows you to refresh set of states, when hint message or error message
+    /// should be visible
+    public func setup(visibleHintStates: HintVisibleStates) {
+        self.hintService.setup(visibleHintStates: visibleHintStates)
+        updateUI()
+    }
+
     /// Allows you to set optional string as text.
     /// Also you can disable automatic validation on this action.
     public func setup(text: String?, validateText: Bool = true) {

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -210,9 +210,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
         hintService.provide(label: hintLabel)
         hintService.configureAppearance()
         hintService.updateContent(containerState: containerState,
-                                  heightLayoutPolicy: .elastic(minHeight: flexibleHeightPolicy.minHeight,
-                                                               bottomSpace: flexibleHeightPolicy.bottomOffset,
-                                                               ignoreEmptyHint: flexibleHeightPolicy.ignoreEmptyHint))
+                                  heightLayoutPolicy: .elastic(policy: flexibleHeightPolicy))
     }
 
     /// Allows you to set constraint on view height, this constraint will be changed if view height is changed later
@@ -413,9 +411,7 @@ private extension UnderlinedTextView {
     func updateUI(animated: Bool = false) {
         fieldService?.updateContent(containerState: containerState)
         hintService.updateContent(containerState: containerState,
-                                  heightLayoutPolicy: .elastic(minHeight: flexibleHeightPolicy.minHeight,
-                                                               bottomSpace: flexibleHeightPolicy.bottomOffset,
-                                                               ignoreEmptyHint: flexibleHeightPolicy.ignoreEmptyHint))
+                                  heightLayoutPolicy: .elastic(policy: flexibleHeightPolicy))
         for service in placeholderServices {
             service.updateContent(fieldState: state, containerState: containerState)
         }


### PR DESCRIPTION
# Что сделано

* жил и был HintService
* только был он скрыт от внешнего мира модификатором internal
* так вот я его закрыл сверху протоколом и дал возможность подменять его, как и сервисы для плейсхолдеров
* а уже после этого с легкостью сделалась задача описанная в issue https://github.com/chausovSurfStudio/TextFieldsCatalog/issues/104
* ну и правки в Example проекте сделал

# На что обратить внимание

* сейчас после создания ПРа еще разок сам гляну, может еще где комментов дописать?
* или вообще дичь идея? именно с вынесением в сервисы
* ну кстати да, спецом не стал указывать где-то import'ы, запустил потом fastlane - поругал меня) так что, надеюсь, swift package не отвалится теперь
* ах, да, с политиками высоты поигрался - убрал там небольшое дублирование и выпилил одну из политик, которую еще в мае 2020 пометил как deprecated (кто проигнорировал его - сам виноват)

# Как протестировать

* в Example проекте изменил у полей ввода с рамкой - хинт должен быть виден всегда
* при этом у всех полей (в том числе и у с рамкой) для поля ввода имени - подсказка отображается еще и в неактивном состоянии
* в целом можно и с другими поиграться при желании полями)