### PR TITLE
trimmed text value if trim spaces option is enabled

### DIFF
--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
@@ -133,6 +133,7 @@ private extension UnderlinedFieldPreset {
         textField.field.autocapitalizationType = .words
         textField.maxLength = 20
         textField.setup(hint: L10n.Presets.Name.hint)
+        textField.trimSpaces = true
 
         textField.maskFormatter = MaskTextFieldFormatter(mask: FormatterMasks.name, notations: FormatterMasks.customNotations())
 
@@ -140,10 +141,6 @@ private extension UnderlinedFieldPreset {
         validator.notValidErrorText = L10n.Presets.Name.notValidError
         validator.largeErrorText = L10n.Presets.Name.largeTextError
         textField.validator = validator
-
-        textField.onEndEditing = { field in
-            field.text = field.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
     }
 
     func tuneFieldForEmail(_ textField: UnderlinedTextField) {

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -61,7 +61,8 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     }
     public var text: String {
         get {
-            return textField.text ?? ""
+            let value = trimSpaces ? trimmedText() : textField.text
+            return value ?? ""
         }
         set {
             setup(text: newValue)
@@ -390,7 +391,7 @@ extension UnderlinedTextField: UITextFieldDelegate {
 
     open func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         if trimSpaces {
-            textField.text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+            textField.text = trimmedText()
         }
         return true
     }
@@ -624,6 +625,10 @@ private extension UnderlinedTextField {
         } else {
             responder?.becomeFirstResponder()
         }
+    }
+
+    func trimmedText() -> String? {
+        return textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
 }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -64,7 +64,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     }
     public var text: String {
         get {
-            return textView.text
+            return trimSpaces ? trimmedText() : textView.text
         }
         set {
             setup(text: newValue)
@@ -370,7 +370,7 @@ extension UnderlinedTextView: UITextViewDelegate {
 
     open func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         if trimSpaces {
-            textView.text = textView.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+            textView.text = trimmedText()
         }
         return true
     }
@@ -499,6 +499,10 @@ private extension UnderlinedTextView {
         } else {
             responder?.becomeFirstResponder()
         }
+    }
+
+    func trimmedText() -> String {
+        return textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
 }


### PR DESCRIPTION
# Что сделано

- была раньше фича такая с `trimSpaces`
- пробелы в начале/конце удалялись после снятия фокуса
- но в теории можно было до снятия фокуса попросить у поля ввода его текст
- и правильнее было бы, если бы он тоже был обрезан
- поправил и в текст филде, и в текст вью

# Как проверить

- в example проекте немножко подправил пресет для поля ввода имени
- а для проверки - можно обработчик onTextChanged повесить и принтить содержимое поля text (или количество символов у этого текста, так еще нагляднее будет)