### PR TITLE
Использование Intrinsic content size вместо установки констрейнта на высоту

### DIFF
--- a/Example/TextFieldsCatalogExample.xcodeproj/project.pbxproj
+++ b/Example/TextFieldsCatalogExample.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		90CB29C92473EE2F001E7563 /* SumTextField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 90CB29C82473EE2F001E7563 /* SumTextField.xib */; };
 		90CB29CB2473F430001E7563 /* SumFieldPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90CB29CA2473F430001E7563 /* SumFieldPreset.swift */; };
 		90CB29CD247453A2001E7563 /* CurrencyPlaceholderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90CB29CC247453A2001E7563 /* CurrencyPlaceholderService.swift */; };
+		90CDFD6025B4C219007B560B /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90CDFD5F25B4C219007B560B /* UIView.swift */; };
 		90D3778321FB21180068F5F8 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D3778221FB21180068F5F8 /* UIViewController.swift */; };
 		90D3778521FB2FF80068F5F8 /* MainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D3778421FB2FF80068F5F8 /* MainButton.swift */; };
 		90D3778821FB3F5A0068F5F8 /* CustomUnderlinedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D3778721FB3F5A0068F5F8 /* CustomUnderlinedTextField.swift */; };
@@ -252,6 +253,7 @@
 		90CB29C82473EE2F001E7563 /* SumTextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SumTextField.xib; sourceTree = "<group>"; };
 		90CB29CA2473F430001E7563 /* SumFieldPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumFieldPreset.swift; sourceTree = "<group>"; };
 		90CB29CC247453A2001E7563 /* CurrencyPlaceholderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyPlaceholderService.swift; sourceTree = "<group>"; };
+		90CDFD5F25B4C219007B560B /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		90D3778221FB21180068F5F8 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		90D3778421FB2FF80068F5F8 /* MainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainButton.swift; sourceTree = "<group>"; };
 		90D3778721FB3F5A0068F5F8 /* CustomUnderlinedTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomUnderlinedTextField.swift; sourceTree = "<group>"; };
@@ -650,6 +652,7 @@
 				90736C6B21F87D65003B8B78 /* UIImage.swift */,
 				90736CC621F8A350003B8B78 /* UITableView.swift */,
 				90736CC821F8A371003B8B78 /* UITableViewCell.swift */,
+				90CDFD5F25B4C219007B560B /* UIView.swift */,
 				90D3778221FB21180068F5F8 /* UIViewController.swift */,
 			);
 			path = Extensions;
@@ -1234,6 +1237,7 @@
 				90CB29CB2473F430001E7563 /* SumFieldPreset.swift in Sources */,
 				904A19B821F9E84300B9A846 /* FieldPresetTableViewCell.swift in Sources */,
 				9082578723C3A79F000767EB /* InfoCoordinator.swift in Sources */,
+				90CDFD6025B4C219007B560B /* UIView.swift in Sources */,
 				90736C7E21F88891003B8B78 /* Strings.swift in Sources */,
 				90736C8421F88ACE003B8B78 /* BaseCoordinator.swift in Sources */,
 				90736CC421F8A330003B8B78 /* MainFieldTableViewCell.swift in Sources */,

--- a/Example/TextFieldsCatalogExample/Flows/Example/Examples/View/ExamplesViewController.swift
+++ b/Example/TextFieldsCatalogExample/Flows/Example/Examples/View/ExamplesViewController.swift
@@ -68,15 +68,8 @@ private extension ExamplesViewController {
     }
 
     func configureFields() {
-        guard
-            let emailField = emailField,
-            let passwordField = passwordField
-        else {
-            return
-        }
-
-        UnderlinedFieldPreset.email.apply(for: emailField, with: emailHeightConstraint)
-        UnderlinedFieldPreset.password.apply(for: passwordField, with: passwordHeightConstraint)
+        UnderlinedFieldPreset.email.apply(for: emailField as Any)
+        UnderlinedFieldPreset.password.apply(for: passwordField as Any)
         emailField.nextInput = passwordField
         passwordField.field.returnKeyType = .done
     }

--- a/Example/TextFieldsCatalogExample/Flows/Example/Examples/View/ExamplesViewController.xib
+++ b/Example/TextFieldsCatalogExample/Flows/Example/Examples/View/ExamplesViewController.xib
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ExamplesViewController" customModule="TextFieldsCatalogExample" customModuleProvider="target">
             <connections>
                 <outlet property="emailField" destination="RJI-fl-7jP" id="yvI-6l-7v6"/>
-                <outlet property="emailHeightConstraint" destination="cJb-z2-Atf" id="1W5-UE-hKq"/>
                 <outlet property="passwordField" destination="47G-cB-7qD" id="va3-Ta-Baz"/>
-                <outlet property="passwordHeightConstraint" destination="EGM-4x-bi7" id="wyQ-rG-ec1"/>
                 <outlet property="view" destination="iN0-l3-epB" id="Q3p-Ee-1CD"/>
             </connections>
         </placeholder>
@@ -22,21 +21,16 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RJI-fl-7jP" customClass="BoxTextField" customModule="TextFieldsCatalogExample" customModuleProvider="target">
+                <view contentMode="scaleToFill" placeholderIntrinsicWidth="320" placeholderIntrinsicHeight="130" translatesAutoresizingMaskIntoConstraints="NO" id="RJI-fl-7jP" customClass="BoxTextField" customModule="TextFieldsCatalogExample" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="20" width="320" height="130"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="130" id="cJb-z2-Atf"/>
-                    </constraints>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="47G-cB-7qD" customClass="BoxTextField" customModule="TextFieldsCatalogExample" customModuleProvider="target">
+                <view contentMode="scaleToFill" placeholderIntrinsicWidth="320" placeholderIntrinsicHeight="130" translatesAutoresizingMaskIntoConstraints="NO" id="47G-cB-7qD" customClass="BoxTextField" customModule="TextFieldsCatalogExample" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="150" width="320" height="130"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="130" id="EGM-4x-bi7"/>
-                    </constraints>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="UCy-nU-wgy"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="47G-cB-7qD" firstAttribute="leading" secondItem="UCy-nU-wgy" secondAttribute="leading" id="7Hi-ej-7tb"/>
@@ -46,8 +40,12 @@
                 <constraint firstItem="RJI-fl-7jP" firstAttribute="top" secondItem="UCy-nU-wgy" secondAttribute="top" constant="20" id="j46-N2-raW"/>
                 <constraint firstItem="RJI-fl-7jP" firstAttribute="trailing" secondItem="UCy-nU-wgy" secondAttribute="trailing" id="vkG-xn-tRR"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="UCy-nU-wgy"/>
             <point key="canvasLocation" x="129.375" y="153.16901408450704"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/TextFieldsCatalogExample/Flows/Main/FieldExample/View/FieldExampleViewController.swift
+++ b/Example/TextFieldsCatalogExample/Flows/Main/FieldExample/View/FieldExampleViewController.swift
@@ -18,10 +18,6 @@ final class FieldExampleViewController: UIViewController {
     @IBOutlet private weak var textFieldContainer: UIView!
     @IBOutlet private weak var descriptionLabel: UILabel!
 
-    // MARK: - NSLayoutConstraints
-
-    @IBOutlet private weak var textFieldContainerHeight: NSLayoutConstraint!
-
     // MARK: - Properties
 
     var output: FieldExampleViewOutput?
@@ -60,13 +56,12 @@ extension FieldExampleViewController: FieldExampleViewInput {
         guard let fieldType = fieldType else {
             return
         }
-        let (newField, height) = fieldType.createField(for: textFieldContainer.bounds)
-        newField.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        let newField = fieldType.createField(for: textFieldContainer.bounds)
         textFieldContainer.addSubview(newField)
+        textFieldContainer.stretch(newField)
         textField = newField
-        textFieldContainerHeight.constant = height
         view.layoutIfNeeded()
-        preset.apply(for: newField, with: textFieldContainerHeight)
+        preset.apply(for: newField)
     }
 
 }

--- a/Example/TextFieldsCatalogExample/Flows/Main/FieldExample/View/FieldExampleViewController.xib
+++ b/Example/TextFieldsCatalogExample/Flows/Main/FieldExample/View/FieldExampleViewController.xib
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FieldExampleViewController" customModule="TextFieldsCatalog" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FieldExampleViewController" customModule="TextFieldsCatalogExample" customModuleProvider="target">
             <connections>
                 <outlet property="changePresetButton" destination="U6W-02-dgj" id="see-El-JJX"/>
                 <outlet property="descriptionLabel" destination="TSs-fx-08U" id="JNy-kl-Fis"/>
                 <outlet property="textFieldContainer" destination="2Xp-dD-FUW" id="IG8-8Y-AjC"/>
-                <outlet property="textFieldContainerHeight" destination="BRu-4X-I9t" id="6Uq-bn-UGY"/>
                 <outlet property="view" destination="iN0-l3-epB" id="Q3p-Ee-1CD"/>
             </connections>
         </placeholder>
@@ -30,14 +27,11 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rn3-M9-xws">
                             <rect key="frame" x="0.0" y="0.0" width="320" height="281"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Xp-dD-FUW">
+                                <view contentMode="scaleToFill" placeholderIntrinsicWidth="320" placeholderIntrinsicHeight="130" translatesAutoresizingMaskIntoConstraints="NO" id="2Xp-dD-FUW">
                                     <rect key="frame" x="0.0" y="10" width="320" height="130"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="130" id="BRu-4X-I9t"/>
-                                    </constraints>
                                 </view>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U6W-02-dgj" customClass="MainButton" customModule="TextFieldsCatalog" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U6W-02-dgj" customClass="MainButton" customModule="TextFieldsCatalogExample" customModuleProvider="target">
                                     <rect key="frame" x="16" y="170" width="94" height="30"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="YaG-5P-idw"/>
@@ -79,6 +73,7 @@
                     </constraints>
                 </scrollView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="rBa-lK-ZEj"/>
             <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="8zG-m9-dei" firstAttribute="leading" secondItem="rBa-lK-ZEj" secondAttribute="leading" id="NI9-vQ-6zd"/>
@@ -87,7 +82,6 @@
                 <constraint firstItem="rBa-lK-ZEj" firstAttribute="bottom" secondItem="8zG-m9-dei" secondAttribute="bottom" id="jWd-Ei-q3I"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="rBa-lK-ZEj"/>
             <point key="canvasLocation" x="48.75" y="-98.767605633802816"/>
         </view>
     </objects>

--- a/Example/TextFieldsCatalogExample/Library/Extensions/UIView.swift
+++ b/Example/TextFieldsCatalogExample/Library/Extensions/UIView.swift
@@ -1,0 +1,24 @@
+//
+//  UIView.swift
+//  TextFieldsCatalogExample
+//
+//  Created by Александр Чаусов on 17.01.2021.
+//  Copyright © 2021 Александр Чаусов. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    func stretch(_ subview: UIView, translatesAutoresizingMaskIntoConstraints: Bool = false) {
+        subview.translatesAutoresizingMaskIntoConstraints = translatesAutoresizingMaskIntoConstraints
+
+        NSLayoutConstraint.activate([
+            subview.topAnchor.constraint(equalTo: self.topAnchor),
+            subview.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            subview.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            subview.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+    }
+
+}

--- a/Example/TextFieldsCatalogExample/Library/Protocols/AppliedPreset.swift
+++ b/Example/TextFieldsCatalogExample/Library/Protocols/AppliedPreset.swift
@@ -12,5 +12,5 @@ import UIKit
 protocol AppliedPreset {
     var name: String { get }
     var description: String { get }
-    func apply(for field: Any, with heightConstraint: NSLayoutConstraint)
+    func apply(for field: Any)
 }

--- a/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/TextFields/BoxTextField/BoxTextField.swift
@@ -92,7 +92,7 @@ private extension BoxTextField {
                                                                insets: UIEdgeInsets(top: 13, left: 16, bottom: 0, right: 16),
                                                                colors: ColorConfiguration(color: Color.UnderlineTextField.placeholder))
         self.setup(placeholderServices: [StaticPlaceholderService(configuration: placeholderConfig)])
-        self.heightLayoutPolicy = .elastic(minHeight: 130, bottomSpace: 5, ignoreEmptyHint: false)
+        self.heightLayoutPolicy = .elastic(minHeight: 136, bottomSpace: 5, ignoreEmptyHint: false)
         self.validationPolicy = .always
     }
 

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/SumFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/SumFieldPreset.swift
@@ -26,11 +26,11 @@ enum SumFieldPreset: CaseIterable, AppliedPreset {
         }
     }
 
-    func apply(for field: Any, with heightConstraint: NSLayoutConstraint) {
+    func apply(for field: Any) {
         guard let field = field as? SumTextField else {
             return
         }
-        apply(for: field, heightConstraint: heightConstraint)
+        apply(for: field)
     }
 
 }
@@ -39,19 +39,18 @@ enum SumFieldPreset: CaseIterable, AppliedPreset {
 
 private extension SumFieldPreset {
 
-    func apply(for textField: SumTextField, heightConstraint: NSLayoutConstraint) {
+    func apply(for textField: SumTextField) {
         switch self {
         case .sum:
-            tuneFieldForSum(textField, heightConstraint: heightConstraint)
+            tuneFieldForSum(textField)
         }
     }
 
-    func tuneFieldForSum(_ textField: SumTextField, heightConstraint: NSLayoutConstraint) {
+    func tuneFieldForSum(_ textField: SumTextField) {
         textField.placeholder = L10n.Presets.Sum.placeholder
         textField.field.autocorrectionType = .no
         textField.field.keyboardType = .decimalPad
         textField.maxLength = 14
-        textField.setup(heightConstraint: heightConstraint)
         textField.configure(supportPlaceholder: "1\u{2009}000\u{2009}₽")
         textField.configure(currencyPlaceholder: "₽")
 

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
@@ -71,11 +71,11 @@ enum UnderlinedFieldPreset: CaseIterable, AppliedPreset {
         }
     }
 
-    func apply(for field: Any, with heightConstraint: NSLayoutConstraint) {
+    func apply(for field: Any) {
         guard let field = field as? UnderlinedTextField else {
             return
         }
-        apply(for: field, heightConstraint: heightConstraint)
+        apply(for: field)
     }
 
 }
@@ -84,10 +84,10 @@ enum UnderlinedFieldPreset: CaseIterable, AppliedPreset {
 
 private extension UnderlinedFieldPreset {
 
-    func apply(for textField: UnderlinedTextField, heightConstraint: NSLayoutConstraint) {
+    func apply(for textField: UnderlinedTextField) {
         switch self {
         case .password:
-            tuneFieldForPassword(textField, heightConstraint: heightConstraint)
+            tuneFieldForPassword(textField)
         case .name:
             tuneFieldForName(textField)
         case .email:
@@ -109,14 +109,13 @@ private extension UnderlinedFieldPreset {
         }
     }
 
-    func tuneFieldForPassword(_ textField: UnderlinedTextField, heightConstraint: NSLayoutConstraint) {
+    func tuneFieldForPassword(_ textField: UnderlinedTextField) {
         textField.placeholder = L10n.Presets.Password.placeholder
         textField.field.autocorrectionType = .no
         textField.field.keyboardType = .asciiCapable
         textField.field.returnKeyType = .next
         textField.field.pasteActionEnabled = false
         textField.mode = .password(.visibleOnNotEmptyText)
-        textField.setup(heightConstraint: heightConstraint)
         textField.setup(hint: L10n.Presets.Password.hint)
 
         let validator = TextFieldValidator(minLength: 8, maxLength: 20, regex: SharedRegex.password)

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedTextViewPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedTextViewPreset.swift
@@ -26,11 +26,11 @@ enum UnderlinedTextViewPreset: CaseIterable, AppliedPreset {
         }
     }
 
-    func apply(for field: Any, with heightConstraint: NSLayoutConstraint) {
+    func apply(for field: Any) {
         guard let field = field as? UnderlinedTextView else {
             return
         }
-        apply(for: field, heightConstraint: heightConstraint)
+        apply(for: field)
     }
 
 }
@@ -39,19 +39,18 @@ enum UnderlinedTextViewPreset: CaseIterable, AppliedPreset {
 
 private extension UnderlinedTextViewPreset {
 
-    func apply(for textView: UnderlinedTextView, heightConstraint: NSLayoutConstraint) {
+    func apply(for textView: UnderlinedTextView) {
         switch self {
         case .comment:
-            tuneFieldForComment(textView, heightConstraint: heightConstraint)
+            tuneFieldForComment(textView)
         }
     }
 
-    func tuneFieldForComment(_ textView: UnderlinedTextView, heightConstraint: NSLayoutConstraint) {
+    func tuneFieldForComment(_ textView: UnderlinedTextView) {
         textView.placeholder = L10n.Presets.Comment.placeholder
         textView.maxLength = 200
         textView.maxTextContainerHeight = 96
         textView.field.autocorrectionType = .no
-        textView.setup(heightConstraint: heightConstraint)
         textView.setup(hint: L10n.Presets.Comment.hint)
 
         let validator = TextFieldValidator(minLength: 30, maxLength: 200, regex: nil)

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/TextFieldType.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/TextFieldType.swift
@@ -57,19 +57,19 @@ enum TextFieldType: CaseIterable {
         }
     }
 
-    /// Returns new instance of needed text field and its default height
-    func createField(for frame: CGRect) -> (UIView, CGFloat) {
+    /// Returns new instance of needed text field
+    func createField(for frame: CGRect) -> UIView {
         switch self {
         case .underlined:
-            return (UnderlinedTextField(frame: frame), 77)
+            return UnderlinedTextField(frame: frame)
         case .box:
-            return (BoxTextField(frame: frame), 130)
+            return BoxTextField(frame: frame)
         case .customUnderlined:
-            return (CustomUnderlinedTextField(frame: frame), 64)
+            return CustomUnderlinedTextField(frame: frame)
         case .underlinedTextView:
-            return (UnderlinedTextView(frame: frame), 77)
+            return UnderlinedTextView(frame: frame)
         case .sumTextField:
-            return (SumTextField(frame: frame), 102)
+            return SumTextField(frame: frame)
         }
     }
 

--- a/TextFieldsCatalog/Resources/Strings/Strings.swift
+++ b/TextFieldsCatalog/Resources/Strings/Strings.swift
@@ -9,21 +9,21 @@ import Foundation
 
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
-public enum L10n {
+internal enum L10n {
 
-  public enum Button {
+  internal enum Button {
     /// Done
-    public static let done = L10n.tr("Localizable", "Button.Done")
+    internal static let done = L10n.tr("Localizable", "Button.Done")
   }
 
-  public enum Errors {
-    public enum TextField {
+  internal enum Errors {
+    internal enum TextField {
       /// Field must be filled
-      public static let empty = L10n.tr("Localizable", "Errors.TextField.empty")
+      internal static let empty = L10n.tr("Localizable", "Errors.TextField.empty")
       /// Wrong format
-      public static let notValid = L10n.tr("Localizable", "Errors.TextField.notValid")
+      internal static let notValid = L10n.tr("Localizable", "Errors.TextField.notValid")
       /// The field must contain at least %@ characters.
-      public static func short(_ p1: Any) -> String {
+      internal static func short(_ p1: Any) -> String {
         return L10n.tr("Localizable", "Errors.TextField.short", String(describing: p1))
       }
     }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -38,9 +38,15 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
             perfromOnContainerStateChangedCall()
         }
     }
+    private var lastViewHeight: CGFloat = 77 {
+        didSet {
+            if oldValue != lastViewHeight {
+                invalidateIntrinsicContentSize()
+                onHeightChanged?(lastViewHeight)
+            }
+        }
+    }
 
-    private var heightConstraint: NSLayoutConstraint?
-    private var lastViewHeight: CGFloat = 0
     /// This flag set to `true` after first text changes and first call of validate() method
     private var isInteractionOccured = false
     /// This flag is set to true and never changes again
@@ -185,6 +191,10 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
         updateUI()
     }
 
+    override open var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: lastViewHeight)
+    }
+
     // MARK: - RespondableField
 
     public var nextInput: UIResponder? {
@@ -228,11 +238,6 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
                                      containerState: containerState)
         service.updateContent(fieldState: state, containerState: containerState)
         placeholderServices.append(service)
-    }
-
-    /// Allows you to set constraint on view height, this constraint will be changed if view height is changed later
-    public func setup(heightConstraint: NSLayoutConstraint) {
-        self.heightConstraint = heightConstraint
     }
 
     /// Allows you to set some string as hint message
@@ -644,30 +649,15 @@ private extension UnderlinedTextField {
         case .flexible(let minHeight, let bottomSpace):
             let hintHeight: CGFloat = hintService?.hintLabelHeight(containerState: containerState) ?? 0
             let actualViewHeight = hintLabel.frame.origin.y + hintHeight + bottomSpace
-            let viewHeight = max(minHeight, actualViewHeight)
-            guard lastViewHeight != viewHeight else {
-                return
-            }
-            lastViewHeight = viewHeight
-            heightConstraint?.constant = viewHeight
-            onHeightChanged?(viewHeight)
+            lastViewHeight = max(minHeight, actualViewHeight)
         case .elastic(let minHeight, let bottomSpace, let ignoreEmptyHint):
-            let viewHeight: CGFloat
             let hintHeight: CGFloat = hintService?.hintLabelHeight(containerState: containerState) ?? 0
-
             if hintHeight != 0 || !ignoreEmptyHint {
                 let actualViewHeight = hintLabel.frame.origin.y + hintHeight + bottomSpace
-                viewHeight = max(minHeight, actualViewHeight)
+                lastViewHeight = max(minHeight, actualViewHeight)
             } else {
-                viewHeight = minHeight
+                lastViewHeight = minHeight
             }
-
-            guard lastViewHeight != viewHeight else {
-                return
-            }
-            lastViewHeight = viewHeight
-            heightConstraint?.constant = viewHeight
-            onHeightChanged?(viewHeight)
         }
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -44,9 +44,15 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
             perfromOnContainerStateChangedCall()
         }
     }
+    private var lastViewHeight: CGFloat = 77 {
+        didSet {
+            if oldValue != lastViewHeight {
+                invalidateIntrinsicContentSize()
+                onHeightChanged?(lastViewHeight)
+            }
+        }
+    }
 
-    private var heightConstraint: NSLayoutConstraint?
-    private var lastViewHeight: CGFloat = 0
     /// This flag set to `true` after first text changes and first call of validate() method
     private var isInteractionOccured = false
 
@@ -160,6 +166,10 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
         updateUI()
     }
 
+    override open var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: lastViewHeight)
+    }
+
     // MARK: - RespondableField
 
     public var nextInput: UIResponder? {
@@ -202,11 +212,6 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
                                      containerState: containerState)
         service.updateContent(fieldState: state, containerState: containerState)
         placeholderServices.append(service)
-    }
-
-    /// Allows you to set constraint on view height, this constraint will be changed if view height is changed later
-    public func setup(heightConstraint: NSLayoutConstraint) {
-        self.heightConstraint = heightConstraint
     }
 
     /// Allows you to set some string as hint message
@@ -520,13 +525,7 @@ private extension UnderlinedTextView {
 
         textViewHeightConstraint.constant = textHeight
         view.layoutIfNeeded()
-
-        guard lastViewHeight != viewHeight else {
-            return
-        }
         lastViewHeight = viewHeight
-        heightConstraint?.constant = viewHeight
-        onHeightChanged?(viewHeight)
     }
 
     func updateClearButtonVisibility() {

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -3,5 +3,5 @@ strings:
   outputs:
     - templateName: structured-swift4
       params:
-        publicAccess: true
+        publicAccess: false
       output: TextFieldsCatalog/Resources/Strings/Strings.swift


### PR DESCRIPTION
# Что сделано

* давно сидела идея с тем, чтобы выпилить из полей ввода необходимость установки констрейнта на высоту, и завязать все изменения высоты на intrinsicContentSize
* в целом это и сделал, и для textField-а, и для textView
* теперь можно при размещении поля ввода в ксибе - просто указать ему placeholder-размер
* а уже дальше поле при инициализации само решит, какая ему высота нужна, в зависимости от настроек

# Как протестировать

* потыкать example проект
* еще попробую на своих проектах затянуть и потестить, но это может затянуться, изменения в коде все же понадобятся - в ксибах ковыряться(
