### PR TITLE
CharacterSet с разрешенными символами

### DIFF
--- a/Example/TextFieldsCatalogExample/Library/Extensions/FormatterMasks.swift
+++ b/Example/TextFieldsCatalogExample/Library/Extensions/FormatterMasks.swift
@@ -17,7 +17,7 @@ extension FormatterMasks {
     private enum Notations {
         enum RussianSymbolsAndSpaces {
             static let character: Character = "R"
-            static let set = CharacterSet(charactersIn: "абвгдеёжзийклмнопрстуфхцчшщъыьэюяФБВГДЕЁЖЗИЙКЛМНОПРСТУФКЦЧШЩЪЫЬЭЮЯ ")
+            static let set = CharacterSet(charactersIn: "абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ ")
         }
     }
 

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
@@ -134,8 +134,14 @@ private extension UnderlinedFieldPreset {
         textField.setup(hint: L10n.Presets.Name.hint)
         textField.trimSpaces = true
         textField.setup(visibleHintStates: [.normal, .active, .error])
+        textField.pasteAllowedChars = true
+        textField.pasteOverflowPolicy = .textThatFits
+        textField.allowedCharacterSet = CharacterSet.letters
+            .union(.decimalDigits)
+            .union(.whitespacesAndNewlines)
+            .union(.init(charactersIn: "№!@#$%^&*()_+1234567890-=><?.,\'\"`«»„“”;:[]{}₽–—`‘/\\"))
 
-        textField.maskFormatter = MaskTextFieldFormatter(mask: FormatterMasks.name, notations: FormatterMasks.customNotations())
+//        textField.maskFormatter = MaskTextFieldFormatter(mask: FormatterMasks.name, notations: FormatterMasks.customNotations())
 
         let validator = TextFieldValidator(minLength: 1, maxLength: 20, regex: SharedRegex.name)
         validator.notValidErrorText = L10n.Presets.Name.notValidError

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedTextViewPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedTextViewPreset.swift
@@ -50,12 +50,12 @@ private extension UnderlinedTextViewPreset {
         textView.placeholder = L10n.Presets.Comment.placeholder
         textView.maxLength = 200
         textView.maxTextContainerHeight = 96
-//        textView.pasteAllowedChars = true
-//        textView.pasteOverflowPolicy = .textThatFits
-//        textView.allowedCharacterSet = CharacterSet.letters
-//            .union(.decimalDigits)
-//            .union(.whitespacesAndNewlines)
-//            .union(.init(charactersIn: "№!@#$%^&*()_+1234567890-=><?.,\'\"`«»„“”;:[]{}₽–—`‘/\\"))
+        textView.pasteAllowedChars = true
+        textView.pasteOverflowPolicy = .textThatFits
+        textView.allowedCharacterSet = CharacterSet.letters
+            .union(.decimalDigits)
+            .union(.whitespacesAndNewlines)
+            .union(.init(charactersIn: "№!@#$%^&*()_+1234567890-=><?.,\'\"`«»„“”;:[]{}₽–—`‘/\\"))
         textView.field.autocorrectionType = .no
         textView.setup(hint: L10n.Presets.Comment.hint)
 

--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedTextViewPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedTextViewPreset.swift
@@ -50,6 +50,12 @@ private extension UnderlinedTextViewPreset {
         textView.placeholder = L10n.Presets.Comment.placeholder
         textView.maxLength = 200
         textView.maxTextContainerHeight = 96
+//        textView.pasteAllowedChars = true
+//        textView.pasteOverflowPolicy = .textThatFits
+//        textView.allowedCharacterSet = CharacterSet.letters
+//            .union(.decimalDigits)
+//            .union(.whitespacesAndNewlines)
+//            .union(.init(charactersIn: "№!@#$%^&*()_+1234567890-=><?.,\'\"`«»„“”;:[]{}₽–—`‘/\\"))
         textView.field.autocorrectionType = .no
         textView.setup(hint: L10n.Presets.Comment.hint)
 

--- a/TextFieldsCatalog.xcodeproj/project.pbxproj
+++ b/TextFieldsCatalog.xcodeproj/project.pbxproj
@@ -404,11 +404,11 @@
 				90AE548F220582C50054E875 /* HeightLayoutPolicy.swift */,
 				90793BFF25A4D47600BC8582 /* HintVisibleStates.swift */,
 				90F487082458329800931146 /* NativePlaceholderBehavior.swift */,
+				BCA359E626316955002D121C /* PasteOverflowPolicy.swift */,
 				902CE2EE21FF702F00AC21D4 /* SharedRegex.swift */,
 				90E13DB02320FD3C004995E4 /* TextFieldMode.swift */,
 				9040B90423C6371000998989 /* TextFieldPasswordModeBehavior.swift */,
 				909CE8E623534E50001E3B7F /* ValidationPolicy.swift */,
-				BCA359E626316955002D121C /* PasteOverflowPolicy.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";

--- a/TextFieldsCatalog/Library/Extensions/UIKit/UITextField.swift
+++ b/TextFieldsCatalog/Library/Extensions/UIKit/UITextField.swift
@@ -29,4 +29,8 @@ extension UITextField {
         }
     }
 
+    func fixCursorPosition(pasteLocation: Int) {
+        moveCursorPosition(text: self.text ?? "", pasteLocation: pasteLocation, replacementString: "")
+    }
+
 }

--- a/TextFieldsCatalog/Library/Extensions/UIKit/UITextView.swift
+++ b/TextFieldsCatalog/Library/Extensions/UIKit/UITextView.swift
@@ -15,8 +15,8 @@ extension UITextView {
         return text.isEmpty
     }
 
-    func moveCursorPosition(text: String, pasteLocation: Int, replacementString: String) {
-        let maxOffset = (text as NSString).length
+    func moveCursorPosition(text: String?, pasteLocation: Int, replacementString: String) {
+        let maxOffset = ((text ?? self.text ?? "") as NSString).length
         let offset = min(maxOffset, pasteLocation + (replacementString as NSString).length)
 
         DispatchQueue.main.async { [weak self] in

--- a/TextFieldsCatalog/Library/Extensions/UIKit/UITextView.swift
+++ b/TextFieldsCatalog/Library/Extensions/UIKit/UITextView.swift
@@ -15,8 +15,8 @@ extension UITextView {
         return text.isEmpty
     }
 
-    func moveCursorPosition(text: String?, pasteLocation: Int, replacementString: String) {
-        let maxOffset = ((text ?? self.text ?? "") as NSString).length
+    func moveCursorPosition(text: String, pasteLocation: Int, replacementString: String) {
+        let maxOffset = (text as NSString).length
         let offset = min(maxOffset, pasteLocation + (replacementString as NSString).length)
 
         DispatchQueue.main.async { [weak self] in
@@ -35,6 +35,10 @@ extension UITextView {
                 self.scrollRectToVisible(caret, animated: true)
             }
         }
+    }
+
+    func fixCursorPosition(pasteLocation: Int) {
+        moveCursorPosition(text: self.text ?? "", pasteLocation: pasteLocation, replacementString: "")
     }
 
 }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -431,22 +431,17 @@ extension UnderlinedTextField: UITextFieldDelegate {
         }
         let newText = text.replacingCharacters(in: textRange, with: replacementString)
 
-        guard pasteAllowedChars || replacementString == string else {
-            // TODO иногда курсор куда-то улетает, даже если вернуть false
-            field.moveCursorPosition(text: field.text ?? "",
-                                     pasteLocation: range.location,
-                                     replacementString: "")
+        let hasNotAllowedChars = replacementString != string
+
+        guard pasteAllowedChars || !hasNotAllowedChars else {
+            field.fixCursorPosition(pasteLocation: range.location)
             return false
         }
 
         switch pasteOverflowPolicy {
         case .noChanges:
             if let maxLength = self.maxLength, newText.count > maxLength {
-                // TODO
-                field.moveCursorPosition(text: field.text ?? "",
-                                         pasteLocation: range.location,
-                                         replacementString: "")
-                return false
+                field.fixCursorPosition(pasteLocation: range.location)
             } else {
                 pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
             }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -117,6 +117,9 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     public var pasteOverflowPolicy: PasteOverflowPolicy = .textThatFits
     public var trimSpaces: Bool = false
     public var allowedCharacterSet: CharacterSet?
+    /// Used when `allowedCharacterSet` is filled.
+    /// If `true` removes all not allowed charecters from paste string.
+    /// If `false` does not paste anything into field.
     public var pasteAllowedChars = true
     public var heightLayoutPolicy: HeightLayoutPolicy = .elastic(policy: .init(minHeight: 77,
                                                                                bottomOffset: 5,

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -443,9 +443,16 @@ extension UnderlinedTextField: UITextFieldDelegate {
             if let maxLength = self.maxLength, newText.count > maxLength {
                 field.fixCursorPosition(pasteLocation: range.location)
             } else {
+                guard hasNotAllowedChars else {
+                    return true
+                }
                 pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
             }
         case .textThatFits:
+            let maxLength = self.maxLength ?? newText.count
+            guard hasNotAllowedChars || newText.count > maxLength else {
+                return true
+            }
             pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
         }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -106,6 +106,8 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     public var validationPolicy: ValidationPolicy = .always
     public var pasteOverflowPolicy: PasteOverflowPolicy = .textThatFits
     public var trimSpaces: Bool = false
+    public var allowedCharacterSet: CharacterSet?
+    public var pasteAllowedChars = true
     public var flexibleHeightPolicy = FlexibleHeightPolicy(minHeight: 77,
                                                            bottomOffset: 5,
                                                            ignoreEmptyHint: true)
@@ -402,29 +404,36 @@ extension UnderlinedTextView: UITextViewDelegate {
     open func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         guard
             let currentText = textView.text,
-            let textRange = Range(range, in: currentText),
-            let maxLength = self.maxLength
+            let textRange = Range(range, in: currentText)
         else {
             return true
         }
 
-        var newText = currentText.replacingCharacters(in: textRange, with: text)
-        switch pasteOverflowPolicy {
-        case .noChanges:
-            return newText.count <= maxLength
-        case .textThatFits:
-            guard newText.count > maxLength else {
-                return true
-            }
+        var replacementString = text
+        if let set = allowedCharacterSet {
+            replacementString = replacementString.components(separatedBy: set.inverted).joined()
+        }
+        let newText = currentText.replacingCharacters(in: textRange, with: replacementString)
 
-            newText = String(newText.prefix(maxLength))
-            setup(text: newText, validateText: false)
+        let hasNotAllowedChars = replacementString != text
 
-            textView.moveCursorPosition(text: newText,
-                                        pasteLocation: range.location,
-                                        replacementString: text)
+        guard pasteAllowedChars || !hasNotAllowedChars else {
+            field.fixCursorPosition(pasteLocation: range.location)
             return false
         }
+
+        switch pasteOverflowPolicy {
+        case .noChanges:
+            if let maxLength = self.maxLength, newText.count > maxLength {
+                field.fixCursorPosition(pasteLocation: range.location)
+            } else {
+                pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
+            }
+        case .textThatFits:
+            pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
+        }
+
+        return false
     }
 
     open func textViewDidChange(_ textView: UITextView) {
@@ -544,6 +553,17 @@ private extension UnderlinedTextView {
         return textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    func pasteText(_ text: String, pasteLocation: Int, replacementString string: String) {
+        let maxLength = self.maxLength ?? text.count
+        let newText = String(text.prefix(maxLength))
+//        DispatchQueue.main.async {
+            self.setup(text: newText, validateText: false)
+//        }
+
+        textView.moveCursorPosition(text: newText,
+                                    pasteLocation: pasteLocation,
+                                    replacementString: string)
+    }
 }
 
 // MARK: - Updating

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -427,9 +427,16 @@ extension UnderlinedTextView: UITextViewDelegate {
             if let maxLength = self.maxLength, newText.count > maxLength {
                 field.fixCursorPosition(pasteLocation: range.location)
             } else {
+                guard hasNotAllowedChars else {
+                    return true
+                }
                 pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
             }
         case .textThatFits:
+            let maxLength = self.maxLength ?? newText.count
+            guard hasNotAllowedChars || newText.count > maxLength else {
+                return true
+            }
             pasteText(newText, pasteLocation: range.location, replacementString: replacementString)
         }
 
@@ -556,10 +563,7 @@ private extension UnderlinedTextView {
     func pasteText(_ text: String, pasteLocation: Int, replacementString string: String) {
         let maxLength = self.maxLength ?? text.count
         let newText = String(text.prefix(maxLength))
-//        DispatchQueue.main.async {
-            self.setup(text: newText, validateText: false)
-//        }
-
+        self.setup(text: newText, validateText: false)
         textView.moveCursorPosition(text: newText,
                                     pasteLocation: pasteLocation,
                                     replacementString: string)


### PR DESCRIPTION
# Что сделано
- добавила CharacterSet в котором можно указать те символы, которые можно вводить в поле
- добавила свойство pasteAllowedChars
  -  если оно true и мы вставляем строку, в которой есть запрещенные символы, они обрежутся, останутся только разрешенные
  - если false, ничего не вставится
  - не стала делать enum, уж больно сложно получалось с pasteOverflowPolicy
  - там и так все переписать пришлось 🙃
- про тот [баг в textView](https://surfnetwork.slack.com/archives/DSBMVCR3M/p1620724212015000), когда при изменении текста в shouldChangeTextInRange, буквы автоматически становятся большими:
  - добавила несколько проверок, чтобы код textView.text = text не вызывался без лишней необходимости
  - вроде больше не видела его
  - но скорее всего он так и остался, просто теперь найти сложнее, но он в целом довольно странный, чинился после передвижения курсора
  - кто знает, что там внутри
- добавила немного кода в пресеты, чтобы было поудобнее менять и проверять