### PR TITLE
Мелкие фиксы

### DIFF
--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -322,9 +322,8 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     }
 
     /// Reset only error state and update all UI elements
-    public func resetErrorState() {
-        error = false
-        updateUI(animated: true)
+    public func resetErrorState(animated: Bool = true) {
+        removeError(animated: animated)
     }
 
 }
@@ -387,7 +386,7 @@ extension UnderlinedTextField {
 
     @objc
     open func textfieldEditingChange(_ textField: UITextField) {
-        removeError()
+        removeError(animated: false)
         performOnTextChangedCall()
         updatePasswordButtonVisibility()
         for service in placeholderServices {
@@ -483,7 +482,7 @@ extension UnderlinedTextField: MaskedTextFieldDelegateListener {
 
     open func textField(_ textField: UITextField, didFillMandatoryCharacters complete: Bool, didExtractValue value: String) {
         maskFormatter?.textField(textField, didFillMandatoryCharacters: complete, didExtractValue: value)
-        removeError()
+        removeError(animated: false)
         performOnTextChangedCall()
         updatePasswordButtonVisibility()
         for service in placeholderServices {
@@ -632,11 +631,11 @@ private extension UnderlinedTextField {
         }
     }
 
-    func removeError() {
+    func removeError(animated: Bool) {
         if error {
             hintService.showHint()
             error = false
-            updateUI(animated: false)
+            updateUI(animated: animated)
         }
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -326,6 +326,13 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
         removeError(animated: animated)
     }
 
+    /// Allows you to change base height for view
+    /// (inner property with last value of height),
+    /// recommend to call before working with field
+    public func updateBaseHeight(_ height: CGFloat) {
+        self.lastViewHeight = height
+    }
+
 }
 
 // MARK: - Configure

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -292,6 +292,13 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
         removeError(animated: animated)
     }
 
+    /// Allows you to change base height for view
+    /// (inner property with last value of height),
+    /// recommend to call before working with field
+    public func updateBaseHeight(_ height: CGFloat) {
+        self.lastViewHeight = height
+    }
+
 }
 
 // MARK: - Configure

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -288,9 +288,8 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     }
 
     /// Reset only error state and update all UI elements
-    public func resetErrorState() {
-        error = false
-        updateUI(animated: true)
+    public func resetErrorState(animated: Bool = true) {
+        removeError(animated: animated)
     }
 
 }
@@ -445,7 +444,7 @@ extension UnderlinedTextView: UITextViewDelegate {
 
     open func textViewDidChange(_ textView: UITextView) {
         updateClearButtonVisibility()
-        removeError()
+        removeError(animated: true)
         performOnTextChangedCall()
         for service in placeholderServices {
             service.updateAfterTextChanged(fieldState: state)
@@ -507,11 +506,11 @@ private extension UnderlinedTextView {
         }
     }
 
-    func removeError() {
+    func removeError(animated: Bool) {
         if error {
             hintService.showHint()
             error = false
-            updateUI(animated: true)
+            updateUI(animated: animated)
         } else {
             updateViewHeight()
             lineService?.updateLineFrame(fieldState: state)


### PR DESCRIPTION
Здесь решения для двух проблем:

* неверная логика метода reseterrorState (в случае, когда hint не установлен, но устанавливается ошибка - сброс ее через этот метод приведет к отображению errorMessage как хинта) - решено путем вызова в этом методе внутреннего метода removeError
* бывают случаи, когда необходимо изменить значение переменной `lastViewHeight` - реализовано через новый метод