### PR TITLE
Новый метод для интерфейса тулбара + мелкие фиксы

### DIFF
--- a/TextFieldsCatalog.podspec
+++ b/TextFieldsCatalog.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "TextFieldsCatalog"
-  s.version = "0.15.0"
+  s.version = "0.16.0"
   s.summary = "This is catalog of various input field with great opportunities for validation and formatting."
   s.homepage = "https://github.com/chausovSurfStudio/TextFieldsCatalog"
   s.license = { :type => "MIT", :file => "LICENSE" }

--- a/TextFieldsCatalog.xcodeproj/project.pbxproj
+++ b/TextFieldsCatalog.xcodeproj/project.pbxproj
@@ -1061,7 +1061,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.15.0;
+				MARKETING_VERSION = 0.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = surf.TextFieldsCatalog;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1091,7 +1091,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.15.0;
+				MARKETING_VERSION = 0.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = surf.TextFieldsCatalog;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/TextFieldsCatalog/Library/Protocols/TextField/GuidedTextField.swift
+++ b/TextFieldsCatalog/Library/Protocols/TextField/GuidedTextField.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Protocols for manageable text field, which can switch responder or resign it
-public protocol GuidedTextField: class {
+public protocol GuidedTextField: AnyObject {
     var havePreviousInput: Bool { get }
     var haveNextInput: Bool { get }
 

--- a/TextFieldsCatalog/Library/Protocols/TextFieldValidation.swift
+++ b/TextFieldsCatalog/Library/Protocols/TextFieldValidation.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public protocol TextFieldValidation: class {
+public protocol TextFieldValidation: AnyObject {
     func validate(_ text: String?) -> (isValid: Bool, errorMessage: String?)
 }

--- a/TextFieldsCatalog/Library/Protocols/ToolBarInterface.swift
+++ b/TextFieldsCatalog/Library/Protocols/ToolBarInterface.swift
@@ -17,6 +17,8 @@ public protocol ToolBarInterface: UIView {
     var guidedField: GuidedTextField? { get set }
     /// In this method you have to update your toolbars's appearance via field states
     func updateNavigationButtons()
+    /// Invokes when text in connected field did change
+    func textDidChange(text: String)
 }
 
 public extension ToolBarInterface {
@@ -28,6 +30,7 @@ public extension ToolBarInterface {
         }
     }
 
-    func updateNavigationButtons() {
-    }
+    func updateNavigationButtons() {}
+
+    func textDidChange(text: String) {}
 }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -288,6 +288,7 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
             validate()
         }
         updateUI(animated: animated)
+        toolbar?.textDidChange(text: self.text)
     }
 
     /// Allows to set accessibilityIdentifier for textField and its internal elements
@@ -697,7 +698,7 @@ private extension UnderlinedTextField {
         let maxLength = self.maxLength ?? newText.count
         let newText = String(newText.prefix(maxLength))
         setup(text: newText, validateText: false)
-
+        performOnTextChangedCall()
         field.moveCursorPosition(text: newText,
                                  pasteLocation: pasteLocation,
                                  replacementString: string)

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -322,9 +322,15 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     }
 
     /// Reset only error state and update all UI elements
-    public func resetErrorState() {
-        error = false
-        updateUI(animated: true)
+    public func resetErrorState(animated: Bool = true) {
+        removeError(animated: animated)
+    }
+
+    /// Allows you to change base height for view
+    /// (inner property with last value of height),
+    /// recommend to call before working with field
+    public func updateBaseHeight(_ height: CGFloat) {
+        self.lastViewHeight = height
     }
 
 }
@@ -387,7 +393,7 @@ extension UnderlinedTextField {
 
     @objc
     open func textfieldEditingChange(_ textField: UITextField) {
-        removeError()
+        removeError(animated: false)
         performOnTextChangedCall()
         updatePasswordButtonVisibility()
         for service in placeholderServices {
@@ -483,7 +489,7 @@ extension UnderlinedTextField: MaskedTextFieldDelegateListener {
 
     open func textField(_ textField: UITextField, didFillMandatoryCharacters complete: Bool, didExtractValue value: String) {
         maskFormatter?.textField(textField, didFillMandatoryCharacters: complete, didExtractValue: value)
-        removeError()
+        removeError(animated: false)
         performOnTextChangedCall()
         updatePasswordButtonVisibility()
         for service in placeholderServices {
@@ -632,11 +638,11 @@ private extension UnderlinedTextField {
         }
     }
 
-    func removeError() {
+    func removeError(animated: Bool) {
         if error {
             hintService.showHint()
             error = false
-            updateUI(animated: false)
+            updateUI(animated: animated)
         }
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -60,6 +60,10 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
     private var hintService: AbstractHintService = HintService(configuration: .default)
     private var placeholderServices: [AbstractPlaceholderService] = [FloatingPlaceholderService(configuration: .defaultForTextField)]
 
+    // MARK: - Open Properties
+
+    open var maxLength: Int?
+
     // MARK: - Public Properties
 
     public var field: InnerTextField {
@@ -110,7 +114,6 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
             toolbar?.updateNavigationButtons()
         }
     }
-    public var maxLength: Int?
     public var hideOnReturn: Bool = true
     public var validateWithFormatter: Bool = false
     public var validationPolicy: ValidationPolicy = .always
@@ -667,6 +670,7 @@ private extension UnderlinedTextField {
     func performOnTextChangedCall() {
         isInteractionOccured = isInteractionOccured ? isInteractionOccured : !textField.isEmpty
         isTextChanged = isTextChanged ? isTextChanged : !textField.isEmpty
+        toolbar?.textDidChange(text: self.text)
         onTextChanged?(self)
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -288,9 +288,15 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     }
 
     /// Reset only error state and update all UI elements
-    public func resetErrorState() {
-        error = false
-        updateUI(animated: true)
+    public func resetErrorState(animated: Bool = true) {
+        removeError(animated: animated)
+    }
+
+    /// Allows you to change base height for view
+    /// (inner property with last value of height),
+    /// recommend to call before working with field
+    public func updateBaseHeight(_ height: CGFloat) {
+        self.lastViewHeight = height
     }
 
 }
@@ -445,7 +451,7 @@ extension UnderlinedTextView: UITextViewDelegate {
 
     open func textViewDidChange(_ textView: UITextView) {
         updateClearButtonVisibility()
-        removeError()
+        removeError(animated: true)
         performOnTextChangedCall()
         for service in placeholderServices {
             service.updateAfterTextChanged(fieldState: state)
@@ -507,11 +513,11 @@ private extension UnderlinedTextView {
         }
     }
 
-    func removeError() {
+    func removeError(animated: Bool) {
         if error {
             hintService.showHint()
             error = false
-            updateUI(animated: true)
+            updateUI(animated: animated)
         } else {
             updateViewHeight()
             lineService?.updateLineFrame(fieldState: state)

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -63,7 +63,11 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
     private var lineService: LineService?
     private var placeholderServices: [AbstractPlaceholderService] = [FloatingPlaceholderService(configuration: .defaultForTextView)]
 
-    // MARK: - Properties
+    // MARK: - Open Properties
+
+    open var maxLength: Int?
+
+    // MARK: - Public Properties
 
     public var field: UITextView {
         return textView
@@ -101,7 +105,6 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
             toolbar?.updateNavigationButtons()
         }
     }
-    public var maxLength: Int?
     public var hideClearButton = false
     public var validationPolicy: ValidationPolicy = .always
     public var pasteOverflowPolicy: PasteOverflowPolicy = .textThatFits
@@ -544,6 +547,7 @@ private extension UnderlinedTextView {
 
     func performOnTextChangedCall() {
         isInteractionOccured = isInteractionOccured ? isInteractionOccured : !textView.isEmpty
+        toolbar?.textDidChange(text: self.text)
         onTextChanged?(self)
     }
 

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -254,6 +254,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
             validate()
         }
         updateUI(animated: animated)
+        toolbar?.textDidChange(text: self.text)
     }
 
     /// Allows to set accessibilityIdentifier for textView and its internal elements
@@ -574,6 +575,7 @@ private extension UnderlinedTextView {
         let maxLength = self.maxLength ?? text.count
         let newText = String(text.prefix(maxLength))
         self.setup(text: newText, validateText: false)
+        performOnTextChangedCall()
         textView.moveCursorPosition(text: newText,
                                     pasteLocation: pasteLocation,
                                     replacementString: string)


### PR DESCRIPTION
В сборку вошли несколько задач и фиксов

https://github.com/chausovSurfStudio/TextFieldsCatalog/pull/117
https://github.com/chausovSurfStudio/TextFieldsCatalog/pull/119
* стало возможным добавить счетчик символов в тулбар, добавился новый метод в его интерфейсе
* переменная maxLength поменяла свой уровень доступа и стала `open`

https://github.com/chausovSurfStudio/TextFieldsCatalog/pull/118
* поправлена логика метода `resetErrorState`
* добавлена возможность изменить значение переменной `lastViewHeight`, чтобы в начале работы избежать лишний вызов замыкания `onHeightChanged`
