### PR TITLE
Возможность выключать несколько действий редактирования

### DIFF
--- a/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
+++ b/Example/TextFieldsCatalogExample/TextFields/Types and presets/Presets/UnderlinedFieldPreset.swift
@@ -114,7 +114,7 @@ private extension UnderlinedFieldPreset {
         textField.field.autocorrectionType = .no
         textField.field.keyboardType = .asciiCapable
         textField.field.returnKeyType = .next
-        textField.field.pasteActionEnabled = false
+        textField.disable(editActions: [.paste])
         textField.mode = .password(.visibleOnNotEmptyText)
         textField.setup(hint: L10n.Presets.Password.hint)
 

--- a/TextFieldsCatalog.xcodeproj/project.pbxproj
+++ b/TextFieldsCatalog.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		397518DB26B97E4D00992617 /* StandardEditActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397518DA26B97E4D00992617 /* StandardEditActions.swift */; };
+		397518E526B9911300992617 /* InnerTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397518E426B9911300992617 /* InnerTextView.swift */; };
 		50B6430D7DAE7D25EA168780 /* Pods_TextFieldsCatalog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE597D7226F11C5666C0ACD9 /* Pods_TextFieldsCatalog.framework */; };
 		7F638D51D41E729487900C9C /* Pods_TextFieldsCatalogTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D90AA463DFFF21B3B7A640F /* Pods_TextFieldsCatalogTests.framework */; };
 		902CE2E821FF6D6D00AC21D4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 902CE2EA21FF6D6D00AC21D4 /* Localizable.strings */; };
@@ -107,6 +109,8 @@
 		2544D9C7000E4E9EEFE58E84 /* Pods-TextFieldsCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TextFieldsCatalog.release.xcconfig"; path = "Pods/Target Support Files/Pods-TextFieldsCatalog/Pods-TextFieldsCatalog.release.xcconfig"; sourceTree = "<group>"; };
 		2D90AA463DFFF21B3B7A640F /* Pods_TextFieldsCatalogTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TextFieldsCatalogTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E9721A780F7BB9DF0720B41 /* Pods-TextFieldsCatalogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TextFieldsCatalogTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TextFieldsCatalogTests/Pods-TextFieldsCatalogTests.release.xcconfig"; sourceTree = "<group>"; };
+		397518DA26B97E4D00992617 /* StandardEditActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardEditActions.swift; sourceTree = "<group>"; };
+		397518E426B9911300992617 /* InnerTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerTextView.swift; sourceTree = "<group>"; };
 		495724198506E09563838E8F /* Pods-TextFieldsCatalog-TextFieldsCatalogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TextFieldsCatalog-TextFieldsCatalogTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TextFieldsCatalog-TextFieldsCatalogTests/Pods-TextFieldsCatalog-TextFieldsCatalogTests.release.xcconfig"; sourceTree = "<group>"; };
 		902CE2E921FF6D6D00AC21D4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		902CE2EB21FF6D7D00AC21D4 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -309,6 +313,7 @@
 			children = (
 				9038640321FF597600BAA761 /* CommonButton.swift */,
 				9038640521FF599D00BAA761 /* InnerDesignableView.swift */,
+				397518E426B9911300992617 /* InnerTextView.swift */,
 				9038640721FF59BC00BAA761 /* InnerTextField.swift */,
 			);
 			path = BaseClasses;
@@ -348,6 +353,7 @@
 			children = (
 				90BB47262200651800F6DB39 /* AssetManager.swift */,
 				902CE2F021FF707E00AC21D4 /* FormatterMasks.swift */,
+				397518DA26B97E4D00992617 /* StandardEditActions.swift */,
 				902CE2F221FF70B000AC21D4 /* MaskTextFieldFormatter.swift */,
 				902CE2F421FF70C500AC21D4 /* TextFieldValidator.swift */,
 			);
@@ -842,6 +848,7 @@
 				90AE5490220582C50054E875 /* HeightLayoutPolicy.swift in Sources */,
 				90EE54B7245724E60099C048 /* AbstractPlaceholderService.swift in Sources */,
 				902CE2F321FF70B000AC21D4 /* MaskTextFieldFormatter.swift in Sources */,
+				397518DB26B97E4D00992617 /* StandardEditActions.swift in Sources */,
 				902CE2F521FF70C500AC21D4 /* TextFieldValidator.swift in Sources */,
 				902CE2EF21FF702F00AC21D4 /* SharedRegex.swift in Sources */,
 				903863FE21FF590700BAA761 /* Color.swift in Sources */,
@@ -866,6 +873,7 @@
 				9038640021FF592100BAA761 /* UIColor.swift in Sources */,
 				9038641021FF5A3600BAA761 /* IconButton.swift in Sources */,
 				902CE30221FF719B00AC21D4 /* UnderlinedTextField.swift in Sources */,
+				397518E526B9911300992617 /* InnerTextView.swift in Sources */,
 				90EE54BE245740AE0099C048 /* StaticPlaceholderService.swift in Sources */,
 				902CE2F821FF70E500AC21D4 /* ConfigurationParameters.swift in Sources */,
 				90E13DB12320FD3C004995E4 /* TextFieldMode.swift in Sources */,

--- a/TextFieldsCatalog/Library/BaseClasses/InnerTextField.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerTextField.swift
@@ -13,7 +13,7 @@ public final class InnerTextField: UITextField {
 
     // MARK: - Private Properties
 
-    private var editActions: [StandardEditActions: Bool]? = nil
+    private var disabledActions: [StandardEditActions]?
 
     // MARK: - Properties
 
@@ -42,12 +42,10 @@ public final class InnerTextField: UITextField {
     // MARK: - UITextField
 
     override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if let actions = editActions {
-            for editAction in actions where editAction.key.selector == action {
-                return editAction.value
-            }
+        guard disabledActions?.first(where: { $0.selector == action }) != nil else {
+            return super.canPerformAction(action, withSender: sender)
         }
-        return super.canPerformAction(action, withSender: sender)
+        return false
     }
 
     override public func textRect(forBounds bounds: CGRect) -> CGRect {
@@ -85,14 +83,7 @@ public final class InnerTextField: UITextField {
     // MARK: - Internal Methods
 
     func disableEditActions(only actions: [StandardEditActions]?) {
-        guard let actions = actions else {
-            editActions = nil
-            return
-        }
-        editActions = [:]
-        actions.forEach {
-            editActions?[$0] = false
-        }
+        disabledActions = actions
     }
 
     // MARK: - Public Methods

--- a/TextFieldsCatalog/Library/BaseClasses/InnerTextField.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerTextField.swift
@@ -11,9 +11,12 @@ import UIKit
 /// Class for UITextField with some extra features, it uses inside custom textFields in the project
 public final class InnerTextField: UITextField {
 
+    // MARK: - Private Properties
+
+    private var editActions: [StandardEditActions: Bool]? = nil
+
     // MARK: - Properties
 
-    public var pasteActionEnabled: Bool = true
     /// if set to true, the textfield's default behavior applies:
     /// In inSecureTextEntry mode the text will be reset after trying to continue typing
     public var resetSecureInput: Bool = false
@@ -39,8 +42,10 @@ public final class InnerTextField: UITextField {
     // MARK: - UITextField
 
     override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if !pasteActionEnabled, action == #selector(UIResponderStandardEditActions.paste(_:)) {
-            return false
+        if let actions = editActions {
+            for editAction in actions where editAction.key.selector == action {
+                return editAction.value
+            }
         }
         return super.canPerformAction(action, withSender: sender)
     }
@@ -78,6 +83,19 @@ public final class InnerTextField: UITextField {
     }
 
     // MARK: - Internal Methods
+
+    func disableEditActions(only actions: [StandardEditActions]?) {
+        guard let actions = actions else {
+            editActions = nil
+            return
+        }
+        editActions = [:]
+        actions.forEach {
+            editActions?[$0] = false
+        }
+    }
+
+    // MARK: - Public Methods
 
     public func fixCursorPosition() {
         let beginning = beginningOfDocument

--- a/TextFieldsCatalog/Library/BaseClasses/InnerTextView.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerTextView.swift
@@ -12,30 +12,21 @@ public final class InnerTextView: UITextView {
 
     // MARK: - Private Properties
 
-    private var editActions: [StandardEditActions: Bool]? = nil
+    private var disabledActions: [StandardEditActions]?
 
     // MARK: - UITextView
 
     override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if let actions = editActions {
-            for editAction in actions where editAction.key.selector == action {
-                return editAction.value
-            }
+        guard disabledActions?.first(where: { $0.selector == action }) != nil else {
+            return super.canPerformAction(action, withSender: sender)
         }
-        return super.canPerformAction(action, withSender: sender)
+        return false
     }
 
     // MARK: - Internal Methods
 
     func disableEditActions(only actions: [StandardEditActions]?) {
-        guard let actions = actions else {
-            editActions = nil
-            return
-        }
-        editActions = [:]
-        actions.forEach {
-            editActions?[$0] = false
-        }
+        disabledActions = actions
     }
 
 }

--- a/TextFieldsCatalog/Library/BaseClasses/InnerTextView.swift
+++ b/TextFieldsCatalog/Library/BaseClasses/InnerTextView.swift
@@ -1,0 +1,41 @@
+//
+//  InnerTextView.swift
+//  TextFieldsCatalog
+//
+//  Created by Никита Гагаринов on 03.08.2021.
+//
+
+import UIKit
+
+/// Class for UITextView with some extra features, it uses inside custom textViews in the project
+public final class InnerTextView: UITextView {
+
+    // MARK: - Private Properties
+
+    private var editActions: [StandardEditActions: Bool]? = nil
+
+    // MARK: - UITextView
+
+    override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if let actions = editActions {
+            for editAction in actions where editAction.key.selector == action {
+                return editAction.value
+            }
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    // MARK: - Internal Methods
+
+    func disableEditActions(only actions: [StandardEditActions]?) {
+        guard let actions = actions else {
+            editActions = nil
+            return
+        }
+        editActions = [:]
+        actions.forEach {
+            editActions?[$0] = false
+        }
+    }
+
+}

--- a/TextFieldsCatalog/Library/Utils/StandardEditActions.swift
+++ b/TextFieldsCatalog/Library/Utils/StandardEditActions.swift
@@ -1,0 +1,46 @@
+//
+//  StandardEditActions.swift
+//  TextFieldsCatalog
+//
+//  Created by Никита Гагаринов on 03.08.2021.
+//  Copyright © 2021 Александр Чаусов. All rights reserved.
+//
+
+import UIKit
+
+/// Contains all standard edit actions for disabling it in fields
+public enum StandardEditActions {
+
+    case cut
+    case copy
+    case paste
+    case select
+    case selectAll
+    case delete
+
+    var selector: Selector {
+        switch self {
+            case .cut:
+                return #selector(UIResponderStandardEditActions.cut)
+            case .copy:
+                return #selector(UIResponderStandardEditActions.copy)
+            case .paste:
+                return #selector(UIResponderStandardEditActions.paste)
+            case .select:
+                return #selector(UIResponderStandardEditActions.select)
+            case .selectAll:
+                return #selector(UIResponderStandardEditActions.selectAll)
+            case .delete:
+                return #selector(UIResponderStandardEditActions.delete)
+        }
+    }
+
+}
+
+public extension Array where Element == StandardEditActions {
+
+    static var all: [StandardEditActions] {
+        return [.cut, .copy, .paste, .selectAll, .delete]
+    }
+
+}

--- a/TextFieldsCatalog/Library/Utils/StandardEditActions.swift
+++ b/TextFieldsCatalog/Library/Utils/StandardEditActions.swift
@@ -40,7 +40,7 @@ public enum StandardEditActions {
 public extension Array where Element == StandardEditActions {
 
     static var all: [StandardEditActions] {
-        return [.cut, .copy, .paste, .selectAll, .delete]
+        return [.cut, .copy, .paste, .select, .selectAll, .delete]
     }
 
 }

--- a/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextField/UnderlinedTextField.swift
@@ -287,6 +287,14 @@ open class UnderlinedTextField: InnerDesignableView, ResetableField, Respondable
         updateUI(animated: animated)
     }
 
+    /// Allows you to disable one or more edit actions
+    /// By default all actions are enabled
+    /// Set .all to disable all actions
+    /// Set nil to enable all actions after the disable has been applied
+    public func disable(editActions: [StandardEditActions]?) {
+        field.disableEditActions(only: editActions)
+    }
+
     /// Allows to set accessibilityIdentifier for textField and its internal elements
     public func setTextFieldIdentifier(_ identifier: String) {
         view.accessibilityIdentifier = identifier

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -15,7 +15,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
 
     // MARK: - IBOutlets
 
-    @IBOutlet private weak var textView: UITextView!
+    @IBOutlet private weak var textView: InnerTextView!
     @IBOutlet private weak var hintLabel: UILabel!
     @IBOutlet private weak var clearButton: IconButton!
 
@@ -65,7 +65,7 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
 
     // MARK: - Properties
 
-    public var field: UITextView {
+    public var field: InnerTextView {
         return textView
     }
     public var text: String {
@@ -251,6 +251,14 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
             validate()
         }
         updateUI(animated: animated)
+    }
+
+    /// Allows you to disable one or more edit actions
+    /// By default all actions are enabled
+    /// Set .all to disable all actions
+    /// Set nil to enable all actions after the disable has been applied
+    public func disable(editActions: [StandardEditActions]?) {
+        field.disableEditActions(only: editActions)
     }
 
     /// Allows to set accessibilityIdentifier for textView and its internal elements

--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.xib
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,7 +12,7 @@
             <connections>
                 <outlet property="clearButton" destination="hDZ-Nk-vhL" id="chR-eD-Shd"/>
                 <outlet property="hintLabel" destination="ZCF-Sk-dJU" id="JZE-Q0-jBY"/>
-                <outlet property="textView" destination="mpb-Kh-o2r" id="ITP-LH-26F"/>
+                <outlet property="textView" destination="mpb-Kh-o2r" id="Kdi-v7-43O"/>
                 <outlet property="textViewBottomConstraint" destination="f8I-TO-SYc" id="Ufa-4w-QKU"/>
                 <outlet property="textViewHeightConstraint" destination="ElT-0x-VoV" id="rXz-bE-ecf"/>
                 <outlet property="textViewTopConstraint" destination="yWg-X3-yZt" id="Vdl-TD-d8G"/>
@@ -23,7 +23,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="76"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="mpb-Kh-o2r">
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="mpb-Kh-o2r" customClass="InnerTextView" customModule="TextFieldsCatalog" customModuleProvider="target">
                     <rect key="frame" x="16" y="28" width="288" height="20"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>


### PR DESCRIPTION
- Добавил интерфейс для выключения действий редактирования для UITextView и UITextField
- Пришлось добавить новое базовое Text View, сделал его по аналогии с Text Field
- Так как сменился базовый TextView, в каждом проекте при обновлении версии нужно будет в ксибе поменять класс у текст вью на InnerTextView, если было наследование UnderlinedTextView
- Свойство `pasteActionEnabled` удалено, так как в нем больше нет необходимости 