### PR TITLE
Поправлен баг TextView с переходом на новую строку - когда поле прыгало

### DIFF
--- a/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
+++ b/TextFieldsCatalog/TextFields/UnderlinedTextView/UnderlinedTextView.swift
@@ -55,6 +55,8 @@ open class UnderlinedTextView: InnerDesignableView, ResetableField, RespondableF
 
     /// This flag set to `true` after first text changes and first call of validate() method
     private var isInteractionOccured = false
+    /// This flag is set to `true` after textView reach maxHeight and used for smooth line break animation
+    private var isMaxHeightReached = false
 
     // MARK: - Services
 
@@ -592,6 +594,16 @@ private extension UnderlinedTextView {
         let freeSpace = freeVerticalSpace(isEmptyHint: hintHeight == 0)
         let actualViewHeight = textHeight + hintHeight + freeSpace
         let viewHeight = max(flexibleHeightPolicy.minHeight, actualViewHeight)
+
+        if isMaxHeightReached {
+            textView.isScrollEnabled = true
+        }
+        if let maxHeight = maxTextContainerHeight, textHeight == maxHeight {
+            isMaxHeightReached = true
+        } else {
+            isMaxHeightReached = false
+            textView.isScrollEnabled = false
+        }
 
         textViewHeightConstraint.constant = textHeight
         view.layoutIfNeeded()


### PR DESCRIPTION
**В чем была проблема:**
По умолчанию у `UITextView` `isScrollEnabled = true`, поэтому в момент когда пользователь переходил на новое поле - `UITextView` проскраливалось на следующую строку (потому что оно знает что оно высотой в одну строку и надо показать пользователю новую), после чего мы обновляли высоту поля и получалось что мы делаем двойную работу.

**В чем грусть**

Баг стал овторяться и на 13 и на 14 iOS

**Решение**

Если мы знаем что высота поля будет обновляться и новые строки будут в видимой части эелемента - отключаем lkz поля `isScrollEnabled`, но после того как мы достигли максимума высоты для TextView возвращаем стандартное поведение с автоматическим подскроллом ` isScrollEnabled = true`

**На что обратить внимание**

Пр создавался из мастера, но направлен теперь на dev/version-1 - потому так много файлов, хотя по сути только один изменен `UnderlinedTextView.swift `

**Как проверить** 

Запустить проект `Example`, обновить в нем поды - перейти на пример многострочного `TextView`